### PR TITLE
dog_modelに残っていたjson形式の削除

### DIFF
--- a/app/models/dog.rb
+++ b/app/models/dog.rb
@@ -1,6 +1,5 @@
 class Dog < ApplicationRecord
   belongs_to :user, optional: true
-  serialize :allergies, coder: JSON, type: Array
 
   # アレルギー情報（表示用）
   ALLERGIES = [
@@ -45,29 +44,22 @@ class Dog < ApplicationRecord
   def recommended_recipes
     recipes = Recipe.published.to_a
 
-    # 🔥 アレルギー除外（TEXT + JSON + tag対応）
+    #  アレルギー除外
     if allergies.present?
-      recipes = recipes.reject do |recipe|
-        allergies.any? do |a|
-          tag = ALLERGY_MAP[a]
+  recipes = recipes.reject do |recipe|
+    next true if recipe.ingredients_json.blank?
 
-          if recipe.ingredients_json.present?
-            ingredients = recipe.ingredients_json.values.flatten
+    ingredients = recipe.ingredients_json.values.flatten
 
-            ingredients.any? do |ing|
-              ing["name"]&.include?(a) ||
-              (tag && ing["tags"]&.include?(tag))
-            end
+    allergies.any? do |a|
+      tag = ALLERGY_MAP[a]
 
-          elsif recipe.ingredients.present?
-            recipe.ingredients.include?(a) ||
-            recipe.ingredients.include?(a.gsub("肉", ""))
-
-          else
-            false
-          end
-        end
+      ingredients.any? do |ing|
+        ing["name"]&.include?(a) ||
+        (tag && ing["tags"]&.include?(tag))
       end
+    end
+  end
     end
 
     # スコアリング

--- a/db/migrate/20260402060552_change_allergies_type_in_dogs.rb
+++ b/db/migrate/20260402060552_change_allergies_type_in_dogs.rb
@@ -1,0 +1,30 @@
+class ChangeAllergiesTypeInDogs < ActiveRecord::Migration[7.2]
+  def up
+    # 既存のデータを修正
+    Dog.find_each do |dog|
+      allergies = dog.attributes['allergies']
+
+      # 空文字列の場合は空配列に変換
+      if allergies.blank?
+        dog.update_column(:allergies, '[]')
+      # JSON配列形式でない場合は配列に変換
+      elsif allergies.is_a?(String) && !allergies.start_with?('[')
+        # カンマ区切りの場合は分割して配列化
+        if allergies.include?(',')
+          items = allergies.split(',').map(&:strip)
+          dog.update_column(:allergies, items.to_json)
+        else
+          # 単一の文字列の場合は配列化
+          dog.update_column(:allergies, [ allergies ].to_json)
+        end
+      end
+    end
+
+    # カラム型を変更
+    change_column :dogs, :allergies, :jsonb, using: 'allergies::jsonb', default: []
+  end
+
+  def down
+    change_column :dogs, :allergies, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_29_035003) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_02_060552) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -33,7 +33,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_29_035003) do
     t.integer "weight"
     t.integer "body_type"
     t.integer "activity_level"
-    t.text "allergies"
+    t.jsonb "allergies", default: []
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
**概要**

デプロイした際に本番のDBがjson形式が残っていることによりエラー。
そのため作動せず修正を行った

**修正箇所**
dog_modelからserialize :allergies, coder: JSON, type: Array 
の削除