### PR TITLE
SNSシェア機能の追加

### DIFF
--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -217,6 +217,47 @@
       </div>
     </div>
 
+    <div class="text-center mt-4">
+  <% share_text = "#{@recipe.name} をチェック！🐶🍽️" %>
+  <% share_url = recipe_url(@recipe) %>
+  <% hashtags = "犬ごはん,手作り犬ごはん" %>
+
+  <%= link_to "🐾 Xでシェアする",
+  "https://twitter.com/intent/tweet?text=#{CGI.escape(share_text)}&url=#{CGI.escape(share_url)}&hashtags=#{hashtags}",
+  target: "_blank",
+  rel: "noopener",
+  class: "btn px-4 py-2",
+  style: "
+    background-color: #444;
+    color: white;
+    border-radius: 30px;
+    font-weight: bold;
+    transition: 0.2s;
+  ",
+  onmouseover: "this.style.backgroundColor='#666'",
+  onmouseout: "this.style.backgroundColor='#444'" %>
+  </div>
+
+<div class="text-center mt-3">
+  <button onclick="copyToClipboard()" 
+    class="btn px-4 py-2"
+    style="
+      background-color: #f4a300;
+      color: white;
+      border-radius: 30px;
+      font-weight: bold;
+    ">
+    📋 URLをコピー
+  </button>
+</div>
+
+<script>
+function copyToClipboard() {
+  const url = "<%= recipe_url(@recipe) %>";
+  navigator.clipboard.writeText(url);
+  alert("URLをコピーしました！Instagramなどでシェアしてね🐶📸");
+}
+</script>
     <!-- 戻るボタン -->
     <div class="text-center mt-4">
       <%= link_to "← 戻る",


### PR DESCRIPTION
**概要**

レシピ詳細ページのUI改善と、SNSシェア機能（X・URLコピー）を追加しました。
ユーザーがレシピを簡単に共有できるようにし、サービスの拡散を促進します。

** 変更内容**

-  X（旧Twitter）シェア機能の追加

レシピ詳細ページにシェアボタンを追加
以下の内容を投稿できるように実装
レシピ名
レシピURL
ハッシュタグ（犬ごはん・手作り犬ごはん）
https://twitter.com/intent/tweet を利用した簡易シェア

- URLコピー機能（Instagram対応）

InstagramはAPI制限があるため直接投稿ではなく代替対応
「URLコピー」ボタンを設置
クリックでレシピURLをクリップボードにコピー
コピー後にアラート表示


**動作確認**
レシピ詳細ページ表示確認
ブックマークの追加・削除
Xシェアボタン遷移確認
URLコピー動作確認（クリップボード反映）