### PR TITLE
ログインユーザーがレシピ投稿ができるように実装

### DIFF
--- a/app/controllers/admin/recipes_controller.rb
+++ b/app/controllers/admin/recipes_controller.rb
@@ -3,22 +3,28 @@ class Admin::RecipesController < ApplicationController
     before_action :require_admin
     before_action :set_recipe, only: [ :show, :update ]
 
-
+    # 下書きレシピ一覧
     def index
       @recipes = Recipe.draft
+    end
+
+    # 承認済みレシピ一覧
+    def published
+      @recipes = Recipe.published
     end
 
     def show
     end
 
     def update
-      if params[:commit] == "承認する"
+      if params[:commit] == I18n.t("admin.recipes.actions.approve")
         @recipe.published!
-      elsif params[:commit] == "却下する"
-        @recipe.rejected!
+        redirect_to published_admin_recipes_path, notice: "承認済みに移動しました"
+      elsif params[:commit] == I18n.t("admin.recipes.actions.reject")
+        redirect_to admin_recipes_path, notice: "却下されました"
+      else
+        redirect_to admin_recipes_path, alert: "不正な操作です"
       end
-
-      redirect_to admin_recipes_path, notice: "更新しました"
     end
 
     private

--- a/app/controllers/admin/recipes_controller.rb
+++ b/app/controllers/admin/recipes_controller.rb
@@ -10,7 +10,7 @@ class Admin::RecipesController < ApplicationController
 
     # 承認済みレシピ一覧
     def published
-      @recipes = Recipe.published
+      @recipes = Recipe.published.order(updated_at: :desc)
     end
 
     def show

--- a/app/controllers/admin/recipes_controller.rb
+++ b/app/controllers/admin/recipes_controller.rb
@@ -17,15 +17,19 @@ class Admin::RecipesController < ApplicationController
     end
 
     def update
-      if params[:commit] == I18n.t("admin.recipes.actions.approve")
+    case params[:commit]
+    when I18n.t("admin.recipes.actions.approve")
         @recipe.published!
         redirect_to published_admin_recipes_path, notice: "承認済みに移動しました"
-      elsif params[:commit] == I18n.t("admin.recipes.actions.reject")
-        redirect_to admin_recipes_path, notice: "却下されました"
-      else
+
+    when I18n.t("admin.recipes.actions.reject")
+        @recipe.rejected!
+        redirect_to admin_recipes_path, notice: "却下しました"
+
+    else
         redirect_to admin_recipes_path, alert: "不正な操作です"
-      end
     end
+  end
 
     private
 

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -7,7 +7,12 @@ class RecipesController < ApplicationController
   end
 
   def confirm
+    filtered = recipe_params[:ingredients_json]["medium"].reject do |i|
+    i["name"].blank? || i["amount"].blank?
+  end
+
     @recipe = current_user.recipes.build(recipe_params)
+    @recipe.ingredients_json["medium"] = filtered
     @recipe.status = "draft"
   end
 
@@ -121,7 +126,9 @@ class RecipesController < ApplicationController
       :activity_level,
       :size,
       :allergies,
-      ingredients_json: {}
+      ingredients_json: {
+        medium: [:name, :amount, :unit]
+      }
     )
   end
 

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -3,13 +3,28 @@ class RecipesController < ApplicationController
   skip_before_action :check_dog_profile, only: [ :index, :show ]
 
   def new
-    @recipe = Recipe.new
+    if params[:recipe]
+      @recipe = Recipe.new(params[:recipe].permit!)
+    else
+      @recipe = Recipe.new
+    end
   end
 
   def confirm
+    @recipe = current_user.recipes.build(recipe_params)
+
     filtered = recipe_params[:ingredients_json]["medium"].reject do |i|
-    i["name"].blank? || i["amount"].blank?
-  end
+      i["name"].blank? || i["amount"].blank?
+    end
+
+    @recipe.ingredients_json["medium"] = filtered
+    @recipe.status = "draft"
+
+      # バリデーションチェック
+      unless @recipe.valid?
+    flash.now[:alert] = "入力内容を確認してください"
+      render :new, status: :unprocessable_entity
+      end
 
     @recipe = current_user.recipes.build(recipe_params)
     @recipe.ingredients_json["medium"] = filtered
@@ -54,6 +69,11 @@ class RecipesController < ApplicationController
   def show
     @recipe = Recipe.find(params[:id])
     @return_to = params[:return_to]
+
+    unless @recipe.published? || current_user&.admin? || @recipe.user == current_user
+      redirect_to recipes_path, alert: "このレシピはまだ公開されていません"
+      return
+    end
 
     # OGP設定
     set_ogp
@@ -110,6 +130,10 @@ class RecipesController < ApplicationController
 
   def select_dog
     @dogs = current_user.dogs
+  end
+
+  def my_recipes
+    @recipes = current_user.recipes.order(created_at: :desc)
   end
 
   private

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -127,7 +127,7 @@ class RecipesController < ApplicationController
       :size,
       :allergies,
       ingredients_json: {
-        medium: [:name, :amount, :unit]
+        medium: [ :name, :amount, :unit ]
       }
     )
   end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -2,6 +2,27 @@ class RecipesController < ApplicationController
   skip_before_action :require_login, only: [ :index, :show ]
   skip_before_action :check_dog_profile, only: [ :index, :show ]
 
+  def new
+    @recipe = Recipe.new
+  end
+
+  def confirm
+    @recipe = current_user.recipes.build(recipe_params)
+    @recipe.status = "draft"
+  end
+
+  def create
+    @recipe = current_user.recipes.build(recipe_params)
+    @recipe.status = "draft"
+
+    if @recipe.save
+      redirect_to recipes_path, notice: "レシピを保存しました。管理者の承認後に公開されます。"
+    else
+      flash.now[:alert] = "レシピの保存に失敗しました。入力内容を確認してください。"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
   def index
     if params[:dog_id].present? && logged_in?
       @dog = current_user.dogs.find(params[:dog_id])
@@ -87,6 +108,22 @@ class RecipesController < ApplicationController
   end
 
   private
+
+  def recipe_params
+    params.require(:recipe).permit(
+      :name,
+      :description,
+      :instructions,
+      :nutrition_note,
+      :nutrition_note,
+      :age_stage,
+      :body_type,
+      :activity_level,
+      :size,
+      :allergies,
+      ingredients_json: {}
+    )
+  end
 
   def set_ogp
     set_meta_tags(

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,6 +19,6 @@ class UsersController < ApplicationController
   private
 
     def user_params
-      params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation)
+      params.require(:user).permit(:first_name, :last_name, :nickname, :email, :password, :password_confirmation)
     end
 end

--- a/app/models/dog.rb
+++ b/app/models/dog.rb
@@ -7,6 +7,11 @@ class Dog < ApplicationRecord
     "卵", "鹿肉", "納豆(大豆)", "鮭", "マグロ", "タラ"
   ].freeze
 
+  # 犬のサイズ
+  SIZES = [
+    "小型犬", "中型犬", "大型犬"
+  ].freeze
+
   # 日本語 → 英語タグ変換
   ALLERGY_MAP = {
     "牛肉" => "beef",

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -16,6 +16,14 @@ class Recipe < ApplicationRecord
 
   validates :name, presence: true
   validates :description, presence: true
+  validates :instructions, presence: true
+  validates :nutrition_note, presence: true
+  validates :age_stage, presence: true
+  validates :body_type, presence: true
+  validates :activity_level, presence: true
+
+  validate :ingredients_presence
+
 
   has_many :bookmarks, dependent: :destroy
   has_many :bookmarked_by_users, through: :bookmarks, source: :user
@@ -136,6 +144,23 @@ class Recipe < ApplicationRecord
 
   private
 
+def ingredients_presence
+  return if ingredients_json.blank?
+
+  ingredients = ingredients_json["medium"]
+
+  # HashでもArrayでも対応
+  ingredients = ingredients.values if ingredients.is_a?(Hash)
+
+  valid = ingredients.any? do |i|
+    i["name"].present? && i["amount"].present?
+  end
+
+  unless valid
+    errors.add(:ingredients_json, "材料を1つ以上入力してください")
+  end
+end
+
   # 指定サイズの材料を調整
   def adjust_ingredients_for_size(size, multiplier)
     ingredients_list = base_ingredients[size.to_s] || base_ingredients[size]
@@ -148,6 +173,7 @@ class Recipe < ApplicationRecord
 
   # サイズに応じた材料を計算
   def calculate_size_ingredients(ingredients, multiplier)
+    ingredients = ingredients.values if ingredients.is_a?(Hash)
     ingredients.map do |ingredient|
       adjusted_ingredient = ingredient.dup
       adjusted_ingredient["amount"] = calculate_amount(

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -2,6 +2,7 @@ class Recipe < ApplicationRecord
   attr_accessor :adjusted_multiplier
   belongs_to :user, optional: true
 
+
   enum :age_stage, { puppy: 0, adult: 1, senior: 2 }, prefix: true
   enum :body_type, { thin: 0, normal: 1, overweight: 2 }, prefix: true
   enum :activity_level, { low: 0, medium: 1, high: 2 }, prefix: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 6 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
+  validates :nickname, presence: true
 
     has_many :dogs, dependent: :destroy
     has_many :recipes, dependent: :destroy

--- a/app/views/admin/recipes/published.html.erb
+++ b/app/views/admin/recipes/published.html.erb
@@ -1,0 +1,15 @@
+<div class="container mt-5">
+  <h2 class="mb-4">承認済みレシピ一覧</h2>
+
+  <% @recipes.each do |recipe| %>
+    <div class="card mb-3 p-3 shadow-sm">
+      <h5><%= recipe.name %></h5>
+      <p class="text-muted"><%= recipe.description %></p>
+      <%= link_to "詳細", admin_recipe_path(recipe), class: "btn btn-outline-primary btn-sm" %>
+    </div>
+  <% end %>
+
+  <% if @recipes.empty? %>
+    <p class="text-muted">承認済みレシピはまだありません</p>
+  <% end %>
+</div>

--- a/app/views/admin/recipes/show.html.erb
+++ b/app/views/admin/recipes/show.html.erb
@@ -1,28 +1,30 @@
-<div class="container mt-5">
-  <div class="card shadow-sm p-5">
-    <h2 class="fw-bold mb-4 text-center"><%= @recipe.title %></h2>
+<div class="container mt-5" style="max-width: 800px;">
+  <div class="card shadow-lg p-5 rounded-4 border-0">
 
-    <p class="text-muted mb-5 text-center">
-      <%= @recipe.content %>
-    </p>
+    <h2 class="fw-bold mb-4 text-center" style="color:#f4a300;">
+      🛠 管理者レビュー
+    </h2>
 
-    <div class="d-flex justify-content-center gap-3">
+    <%= render "recipes/recipe_detail", recipe: @recipe %>
+
+    <div class="d-flex justify-content-center gap-3 mt-4">
       <%= form_with model: [:admin, @recipe], method: :patch do |f| %>
         <%= f.submit "承認する",
-              name: "commit",
-              value: "approve",
-              class: "btn btn-success rounded-pill px-4" %>
+          name: "commit",
+          value: "approve",
+          class: "btn btn-success px-4 rounded-pill" %>
 
         <%= f.submit "却下する",
-              name: "commit",
-              value: "reject",
-              class: "btn btn-danger rounded-pill px-4" %>
+          name: "commit",
+          value: "reject",
+          class: "btn btn-danger px-4 rounded-pill" %>
       <% end %>
     </div>
 
     <div class="text-center mt-4">
       <%= link_to "一覧に戻る", admin_recipes_path,
-          class: "btn btn-secondary btn-lg" %>
+        class: "btn btn-secondary px-4 rounded-pill" %>
     </div>
+
   </div>
 </div>

--- a/app/views/admin/recipes/show.html.erb
+++ b/app/views/admin/recipes/show.html.erb
@@ -9,15 +9,13 @@
 
     <div class="d-flex justify-content-center gap-3 mt-4">
       <%= form_with model: [:admin, @recipe], method: :patch do |f| %>
-        <%= f.submit "承認する",
-          name: "commit",
-          value: "approve",
-          class: "btn btn-success px-4 rounded-pill" %>
+        <%= f.submit t("admin.recipes.actions.approve"),
+  name: "commit",
+  class: "btn btn-success px-4 rounded-pill" %>
 
-        <%= f.submit "却下する",
-          name: "commit",
-          value: "reject",
-          class: "btn btn-danger px-4 rounded-pill" %>
+<%= f.submit t("admin.recipes.actions.reject"),
+  name: "commit",
+  class: "btn btn-danger px-4 rounded-pill" %>
       <% end %>
     </div>
 

--- a/app/views/homes/dashboard.html.erb
+++ b/app/views/homes/dashboard.html.erb
@@ -64,7 +64,7 @@
       text: "あなたのレシピをシェアしましょう" do %>
 
       <%= link_to "投稿する",
-        new_recipe_path, class: "btn btn-warning btn-lg" %>
+        select_action_recipes_path, class: "btn btn-warning btn-lg" %>
 
     <% end %>
 

--- a/app/views/homes/dashboard.html.erb
+++ b/app/views/homes/dashboard.html.erb
@@ -64,8 +64,7 @@
       text: "あなたのレシピをシェアしましょう" do %>
 
       <%= link_to "投稿する",
-        "#",
-        class: "btn btn-warning btn-lg" %>
+        new_recipe_path, class: "btn btn-warning btn-lg" %>
 
     <% end %>
 

--- a/app/views/homes/dashboard.html.erb
+++ b/app/views/homes/dashboard.html.erb
@@ -107,5 +107,25 @@
 
     <% end %>
 
+    <% if current_user.admin? %>
+  <!-- 承認待ちレシピ -->
+  <%= render "homes/card",
+      icon: "bi-list-check",
+      title: "承認待ちレシピ",
+      text: "まだ承認されていないレシピを確認" do %>
+
+      <%= link_to "確認する", admin_recipes_path, class: "btn btn-warning btn-lg" %>
+  <% end %>
+
+  <!-- 承認済みレシピ -->
+  <%= render "homes/card",
+      icon: "bi-check-circle",
+      title: "承認済みレシピ",
+      text: "承認済みレシピの一覧を見る" do %>
+
+      <%= link_to "確認する", published_admin_recipes_path, class: "btn btn-warning btn-lg" %>
+  <% end %>
+<% end %>
+
   </div>
 </div>

--- a/app/views/recipes/_recipe_detail.html.erb
+++ b/app/views/recipes/_recipe_detail.html.erb
@@ -1,0 +1,77 @@
+<div class="container mt-5" style="max-width: 800px;">
+  <div class="card shadow-lg p-5 rounded-4 border-0">
+
+    <!-- タイトル -->
+    <h2 class="fw-bold mb-3 text-center" style="color:#f4a300;">
+      🍽 <%= recipe.name %>
+    </h2>
+
+    <!-- 説明 -->
+    <p class="text-muted mb-4 text-center" style="font-size: 14px;">
+      <%= recipe.description %>
+    </p>
+
+    <!-- 対象犬 -->
+    <div class="mb-4 p-3 rounded-3" style="background-color:#fff8e6;">
+      <h5 class="fw-bold mb-2">🐶 対象のわんちゃん</h5>
+      <div class="d-flex justify-content-around text-center">
+        <div>
+          <small class="text-muted">年齢</small><br>
+          <span class="fw-bold">
+            <%= t("enums.dog.age_stage.#{recipe.age_stage}") %>
+          </span>
+        </div>
+        <div>
+          <small class="text-muted">体型</small><br>
+          <span class="fw-bold">
+            <%= t("enums.dog.body_type.#{recipe.body_type}") %>
+          </span>
+        </div>
+        <div>
+          <small class="text-muted">運動量</small><br>
+          <span class="fw-bold">
+            <%= t("enums.dog.activity_level.#{recipe.activity_level}") %>
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <!-- 材料 -->
+    <div class="mb-4">
+      <h5 class="fw-bold mb-3">🥕 材料（中型犬）</h5>
+      <ul class="list-group list-group-flush">
+        <% recipe.ingredients_json["medium"].values.each do |ingredient| %>
+          <% next if ingredient["name"].blank? || ingredient["amount"].blank? %>
+          <li class="list-group-item d-flex justify-content-between">
+            <span><%= ingredient["name"] %></span>
+            <span class="fw-bold">
+              <%= ingredient["amount"] %><%= ingredient["unit"] %>
+            </span>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+
+    <!-- 作り方 -->
+    <div class="mb-4">
+      <h5 class="fw-bold mb-3">🍳 作り方</h5>
+      <div class="p-3 rounded-3" style="background:#f9f9f9;">
+        <%= simple_format(recipe.instructions) %>
+      </div>
+    </div>
+
+    <!-- 栄養 -->
+    <div class="mb-4">
+      <h5 class="fw-bold mb-3">🌟 栄養ポイント</h5>
+      <div class="p-3 rounded-3" style="background:#f9f9f9;">
+        <%= simple_format(recipe.nutrition_note) %>
+      </div>
+    </div>
+
+    <!-- 投稿者 -->
+    <div class="text-end text-muted mt-4">
+      👤 <%= recipe.user&.nickname || "運営レシピ" %>
+    </div>
+
+  </div>
+</div>

--- a/app/views/recipes/_recipe_detail.html.erb
+++ b/app/views/recipes/_recipe_detail.html.erb
@@ -18,19 +18,19 @@
         <div>
           <small class="text-muted">年齢</small><br>
           <span class="fw-bold">
-            <%= t("enums.dog.age_stage.#{recipe.age_stage}") %>
+            <%= t("enums.dog.age_stage.#{recipe.age_stage}") if recipe.age_stage.present? %>
           </span>
         </div>
         <div>
           <small class="text-muted">体型</small><br>
           <span class="fw-bold">
-            <%= t("enums.dog.body_type.#{recipe.body_type}") %>
+            <%= t("enums.dog.body_type.#{recipe.body_type}") if recipe.body_type.present? %>
           </span>
         </div>
         <div>
           <small class="text-muted">運動量</small><br>
           <span class="fw-bold">
-            <%= t("enums.dog.activity_level.#{recipe.activity_level}") %>
+            <%= t("enums.dog.activity_level.#{recipe.activity_level}") if recipe.activity_level.present? %>
           </span>
         </div>
       </div>
@@ -40,14 +40,17 @@
     <div class="mb-4">
       <h5 class="fw-bold mb-3">🥕 材料（中型犬）</h5>
       <ul class="list-group list-group-flush">
-        <% recipe.ingredients_json["medium"].values.each do |ingredient| %>
-          <% next if ingredient["name"].blank? || ingredient["amount"].blank? %>
-          <li class="list-group-item d-flex justify-content-between">
-            <span><%= ingredient["name"] %></span>
-            <span class="fw-bold">
-              <%= ingredient["amount"] %><%= ingredient["unit"] %>
-            </span>
-          </li>
+        <% if recipe.ingredients_json["medium"].present? %>
+          <% ingredients = recipe.ingredients_json["medium"] %>
+          <% ingredients = ingredients.values if ingredients.is_a?(Hash) %>
+
+          <% ingredients.each do |ingredient| %>
+            <% next if ingredient["name"].blank? || ingredient["amount"].blank? %>
+            <li class="list-group-item d-flex justify-content-between">
+              <span><%= ingredient["name"] %></span>
+              <span class="fw-bold"><%= ingredient["amount"] %><%= ingredient["unit"] %></span>
+            </li>
+          <% end %>
         <% end %>
       </ul>
     </div>

--- a/app/views/recipes/confirm.html.erb
+++ b/app/views/recipes/confirm.html.erb
@@ -1,25 +1,44 @@
-<p><%= @recipe.name %></p>
-<p><%= @recipe.description %></p>
+<%= render "recipes/recipe_detail", recipe: @recipe %>
 
-<h5>🥕 材料</h5>
-<ul>
-  <% @recipe.ingredients_json["medium"].each do |ingredient| %>
-    <li>
-      <%= ingredient["name"] %>：
-      <%= ingredient["amount"] %><%= ingredient["unit"] %>
-    </li>
-  <% end %>
-</ul>
+<%= form_with url: recipes_path, method: :post, data: { turbo: false } do |f| %>
 
-<%= form_with model: @recipe do |f| %>
   <%= hidden_field_tag "recipe[name]", @recipe.name %>
   <%= hidden_field_tag "recipe[description]", @recipe.description %>
+  <%= hidden_field_tag "recipe[instructions]", @recipe.instructions %>
+  <%= hidden_field_tag "recipe[nutrition_note]", @recipe.nutrition_note %>
 
-  <% @recipe.ingredients_json["medium"].each do |ingredient| %>
-    <%= hidden_field_tag "recipe[ingredients_json][medium][][name]", ingredient["name"] %>
-    <%= hidden_field_tag "recipe[ingredients_json][medium][][amount]", ingredient["amount"] %>
-    <%= hidden_field_tag "recipe[ingredients_json][medium][][unit]", ingredient["unit"] %>
+  <% @recipe.ingredients_json["medium"].each_with_index do |ingredient, i| %>
+    <% next if ingredient["name"].blank? || ingredient["amount"].blank? %>
+
+    <%= hidden_field_tag "recipe[ingredients_json][medium][#{i}][name]", ingredient["name"] %>
+    <%= hidden_field_tag "recipe[ingredients_json][medium][#{i}][amount]", ingredient["amount"] %>
+    <%= hidden_field_tag "recipe[ingredients_json][medium][#{i}][unit]", ingredient["unit"] %>
   <% end %>
 
-  <%= f.submit "投稿する" %>
+  <%= hidden_field_tag "recipe[age_stage]", @recipe.age_stage %>
+  <%= hidden_field_tag "recipe[body_type]", @recipe.body_type %>
+  <%= hidden_field_tag "recipe[activity_level]", @recipe.activity_level %>
+
+ <div class="text-center mt-5">
+  <%= link_to "修正する",
+    new_recipe_path(recipe: @recipe.attributes),
+    class: "btn me-3",
+    style: "
+      border-radius: 30px;
+      padding: 10px 25px;
+      border: 2px solid #ccc;
+      color: #555;
+    " %>
+
+  <%= f.submit "レシピを投稿する",
+    class: "btn",
+    style: "
+      background-color: #f4a300;
+      color: white;
+      border-radius: 30px;
+      padding: 10px 25px;
+      font-weight: bold;
+    " %>
+</div>
+
 <% end %>

--- a/app/views/recipes/confirm.html.erb
+++ b/app/views/recipes/confirm.html.erb
@@ -1,0 +1,25 @@
+<p><%= @recipe.name %></p>
+<p><%= @recipe.description %></p>
+
+<h5>🥕 材料</h5>
+<ul>
+  <% @recipe.ingredients_json["medium"].each do |ingredient| %>
+    <li>
+      <%= ingredient["name"] %>：
+      <%= ingredient["amount"] %><%= ingredient["unit"] %>
+    </li>
+  <% end %>
+</ul>
+
+<%= form_with model: @recipe do |f| %>
+  <%= hidden_field_tag "recipe[name]", @recipe.name %>
+  <%= hidden_field_tag "recipe[description]", @recipe.description %>
+
+  <% @recipe.ingredients_json["medium"].each do |ingredient| %>
+    <%= hidden_field_tag "recipe[ingredients_json][medium][][name]", ingredient["name"] %>
+    <%= hidden_field_tag "recipe[ingredients_json][medium][][amount]", ingredient["amount"] %>
+    <%= hidden_field_tag "recipe[ingredients_json][medium][][unit]", ingredient["unit"] %>
+  <% end %>
+
+  <%= f.submit "投稿する" %>
+<% end %>

--- a/app/views/recipes/confirm.html.erb
+++ b/app/views/recipes/confirm.html.erb
@@ -21,14 +21,14 @@
 
  <div class="text-center mt-5">
   <%= link_to "修正する",
-    new_recipe_path(recipe: @recipe.attributes),
-    class: "btn me-3",
-    style: "
-      border-radius: 30px;
-      padding: 10px 25px;
-      border: 2px solid #ccc;
-      color: #555;
-    " %>
+  new_recipe_path(recipe: params[:recipe].permit!),
+  class: "btn me-3",
+  style: "
+    border-radius: 30px;
+    padding: 10px 25px;
+    border: 2px solid #ccc;
+    color: #555;
+  " %>
 
   <%= f.submit "レシピを投稿する",
     class: "btn",

--- a/app/views/recipes/my_recipes.html.erb
+++ b/app/views/recipes/my_recipes.html.erb
@@ -1,0 +1,39 @@
+<div class="container mt-5">
+  <h2 class="text-center mb-4 fw-bold">📖 投稿したレシピ一覧</h2>
+
+  <div class="row g-4">
+    <% @recipes.each do |recipe| %>
+      <div class="col-md-4">
+        <div class="card shadow-sm p-4 h-100 d-flex flex-column">
+
+          <h5 class="fw-bold mb-2"><%= recipe.name %></h5>
+
+          <p class="text-muted small mb-3">
+            <%= truncate(recipe.description, length: 50) %>
+          </p>
+
+          <!-- ステータス -->
+          <div class="mb-3">
+            <% if recipe.published? %>
+              <span class="badge bg-success">公開中</span>
+            <% elsif recipe.rejected? %>
+              <span class="badge bg-danger">却下</span>
+            <% else %>
+              <span class="badge bg-secondary">審査中</span>
+            <% end %>
+          </div>
+
+          <%= link_to "詳細を見る",
+            recipe_path(recipe),
+            class: "btn btn-warning rounded-pill mt-auto text-white" %>
+
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="text-center mt-5">
+    <%= link_to "戻る", select_action_recipes_path,
+      class: "btn btn-outline-secondary rounded-pill px-4" %>
+  </div>
+</div>

--- a/app/views/recipes/new.html.erb
+++ b/app/views/recipes/new.html.erb
@@ -5,7 +5,7 @@
       🐶 レシピ投稿
     </h2>
 
-    <%= form_with model: @recipe, url: confirm_recipes_path do |f| %>
+    <%= form_with model: @recipe, url: confirm_recipes_path, data: { turbo: false } do |f| %>
 
       <!-- レシピ名 -->
       <div class="mb-3">
@@ -13,10 +13,10 @@
         <%= f.text_field :name, class: "form-control", placeholder: "例：ささみと野菜のごはん" %>
       </div>
 
-      <!-- 説明 -->
+     <!-- 対象のわんちゃん -->
       <div class="mb-3">
-        <label class="fw-bold">📝 説明</label>
-        <%= f.text_area :description, class: "form-control", rows: 3 %>
+         <label class="fw-bold">🐶 このレシピはどんなわんちゃん向け？</label>
+         <%= f.text_area :description, class: "form-control", rows: 2, placeholder: "例：体重を増やしたい子犬向け" %>
       </div>
 
 
@@ -42,6 +42,32 @@
     ＋材料を追加
   </button>
 </div>
+
+  <div class="row">
+    <!-- 年齢 -->
+    <div class="col-md-4">
+      <%= f.label :age_stage, "年齢" %>
+      <%= f.select :age_stage,
+  Dog.age_stages.keys.map { |k| [t("enums.dog.age_stage.#{k}"), k] },
+  {}, class: "form-select" %>
+    </div>
+
+    <!-- 体型 -->
+    <div class="col-md-4">
+      <%= f.label :body_type, "体型" %>
+      <%= f.select :body_type,
+  Dog.body_types.keys.map { |k| [t("enums.dog.body_type.#{k}"), k] },
+  {}, class: "form-select" %>
+    </div>
+
+    <!-- 運動量 -->
+    <div class="col-md-4">
+      <%= f.label :activity_level, "運動量" %>
+      <%= f.select :activity_level,
+  Dog.activity_levels.keys.map { |k| [t("enums.dog.activity_level.#{k}"), k] },
+  {}, class: "form-select" %>
+    </div>
+  </div>
 
       <!-- 作り方 -->
       <div class="mb-3">

--- a/app/views/recipes/new.html.erb
+++ b/app/views/recipes/new.html.erb
@@ -1,5 +1,14 @@
 <div class="container mt-5" style="max-width: 800px;">
   <div class="card shadow-lg p-5 rounded-4 border-0">
+  <% if @recipe.errors.any? %>
+    <div class="alert alert-danger">
+      <ul class="mb-0">
+       <% @recipe.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
 
     <h2 class="fw-bold mb-4 text-center" style="color: #f4a300;">
       🐶 レシピ投稿
@@ -25,9 +34,36 @@
   <label class="fw-bold">🥕 材料（中型犬用の量を入力してください。）</label>
 
   <div id="ingredients-fields">
+  <% if @recipe.ingredients_json.present? %>
+    <% ingredients = @recipe.ingredients_json["medium"] %>
+    <% ingredients = ingredients.values if ingredients.is_a?(Hash) %>
+
+    <% ingredients.each do |ingredient| %>
+      <div class="d-flex gap-2 mb-2">
+        <input type="text"
+          name="recipe[ingredients_json][medium][][name]"
+          value="<%= ingredient["name"] %>"
+          class="form-control">
+
+        <input type="number"
+          name="recipe[ingredients_json][medium][][amount]"
+          value="<%= ingredient["amount"] %>"
+          class="form-control">
+
+        <select name="recipe[ingredients_json][medium][][unit]" class="form-select">
+          <option value="g" <%= "selected" if ingredient["unit"] == "g" %>>g</option>
+          <option value="ml" <%= "selected" if ingredient["unit"] == "ml" %>>ml</option>
+          <option value="tsp" <%= "selected" if ingredient["unit"] == "tsp" %>>小さじ</option>
+          <option value="tbsp" <%= "selected" if ingredient["unit"] == "tbsp" %>>大さじ</option>
+          <option value="piece" <%= "selected" if ingredient["unit"] == "piece" %>>個</option>
+        </select>
+      </div>
+    <% end %>
+  <% else %>
+    <!-- 初期表示 -->
     <div class="d-flex gap-2 mb-2">
-      <input type="text" name="recipe[ingredients_json][medium][][name]" placeholder="食材名" class="form-control">
-      <input type="number" name="recipe[ingredients_json][medium][][amount]" placeholder="量" class="form-control">
+      <input type="text" name="recipe[ingredients_json][medium][][name]" class="form-control">
+      <input type="number" name="recipe[ingredients_json][medium][][amount]" class="form-control">
       <select name="recipe[ingredients_json][medium][][unit]" class="form-select">
         <option value="g">g</option>
         <option value="ml">ml</option>
@@ -36,8 +72,8 @@
         <option value="piece">個</option>
       </select>
     </div>
-  </div>
-
+  <% end %>
+</div>
   <button type="button" class="btn btn-outline-secondary btn-sm" onclick="addIngredient()">
     ＋材料を追加
   </button>
@@ -46,7 +82,7 @@
   <div class="row">
     <!-- 年齢 -->
     <div class="col-md-4">
-      <%= f.label :age_stage, "年齢" %>
+      <%= f.label :age_stage, "このレシピの該当タイプ" %>
       <%= f.select :age_stage,
   Dog.age_stages.keys.map { |k| [t("enums.dog.age_stage.#{k}"), k] },
   {}, class: "form-select" %>
@@ -93,6 +129,19 @@
           " %>
       </div>
 
+      <!-- 戻る -->
+      <div class="text-center mt-3">
+        <%= link_to "戻る",
+          select_action_recipes_path,
+          class: "btn px-4 py-2",
+          style: "
+            border-radius: 30px;
+            padding: 10px 25px;
+            border: 2px solid #ccc;
+            color: #555;
+          " %>
+      </div>
+
     <% end %>
 
   </div>
@@ -113,9 +162,9 @@ function addIngredient() {
         <option value="tbsp">大さじ</option>
         <option value="piece">個</option>
       </select>
+      <button type="button" class="btn btn-outline-danger btn-sm" onclick="this.parentElement.remove()">✖</button>
     </div>
   `;
-
   container.insertAdjacentHTML("beforeend", html);
 }
 </script>

--- a/app/views/recipes/new.html.erb
+++ b/app/views/recipes/new.html.erb
@@ -1,0 +1,95 @@
+<div class="container mt-5" style="max-width: 800px;">
+  <div class="card shadow-lg p-5 rounded-4 border-0">
+
+    <h2 class="fw-bold mb-4 text-center" style="color: #f4a300;">
+      🐶 レシピ投稿
+    </h2>
+
+    <%= form_with model: @recipe, url: confirm_recipes_path do |f| %>
+
+      <!-- レシピ名 -->
+      <div class="mb-3">
+        <label class="fw-bold">🍽 レシピ名</label>
+        <%= f.text_field :name, class: "form-control", placeholder: "例：ささみと野菜のごはん" %>
+      </div>
+
+      <!-- 説明 -->
+      <div class="mb-3">
+        <label class="fw-bold">📝 説明</label>
+        <%= f.text_area :description, class: "form-control", rows: 3 %>
+      </div>
+
+
+        <!-- 材料 -->
+      <div class="mb-4">
+  <label class="fw-bold">🥕 材料（中型犬用の量を入力してください。）</label>
+
+  <div id="ingredients-fields">
+    <div class="d-flex gap-2 mb-2">
+      <input type="text" name="recipe[ingredients_json][medium][][name]" placeholder="食材名" class="form-control">
+      <input type="number" name="recipe[ingredients_json][medium][][amount]" placeholder="量" class="form-control">
+      <select name="recipe[ingredients_json][medium][][unit]" class="form-select">
+        <option value="g">g</option>
+        <option value="ml">ml</option>
+        <option value="tsp">小さじ</option>
+        <option value="tbsp">大さじ</option>
+        <option value="piece">個</option>
+      </select>
+    </div>
+  </div>
+
+  <button type="button" class="btn btn-outline-secondary btn-sm" onclick="addIngredient()">
+    ＋材料を追加
+  </button>
+</div>
+
+      <!-- 作り方 -->
+      <div class="mb-3">
+        <label class="fw-bold">🍳 作り方</label>
+        <%= f.text_area :instructions, class: "form-control", rows: 6 %>
+      </div>
+
+      <!-- 栄養ポイント -->
+      <div class="mb-4">
+        <label class="fw-bold">🌟 栄養ポイント</label>
+        <%= f.text_area :nutrition_note, class: "form-control", rows: 4 %>
+      </div>
+
+      <!-- 送信 -->
+      <div class="text-center">
+        <%= f.submit "確認画面へ",
+          class: "btn px-4 py-2",
+          style: "
+            background-color: #f4a300;
+            color: white;
+            border-radius: 30px;
+            font-weight: bold;
+          " %>
+      </div>
+
+    <% end %>
+
+  </div>
+</div>
+
+<script>
+function addIngredient() {
+  const container = document.getElementById("ingredients-fields");
+
+  const html = `
+    <div class="d-flex gap-2 mb-2">
+      <input type="text" name="recipe[ingredients_json][medium][][name]" placeholder="食材名" class="form-control">
+      <input type="number" name="recipe[ingredients_json][medium][][amount]" placeholder="量" class="form-control">
+      <select name="recipe[ingredients_json][medium][][unit]" class="form-select">
+        <option value="g">g</option>
+        <option value="ml">ml</option>
+        <option value="tsp">小さじ</option>
+        <option value="tbsp">大さじ</option>
+        <option value="piece">個</option>
+      </select>
+    </div>
+  `;
+
+  container.insertAdjacentHTML("beforeend", html);
+}
+</script>

--- a/app/views/recipes/select_action.html.erb
+++ b/app/views/recipes/select_action.html.erb
@@ -1,0 +1,39 @@
+<div class="container mt-5">
+  <div class="text-center mb-5">
+    <h2 class="fw-bold">🐶 レシピ投稿</h2>
+    <p class="text-muted">やりたい操作を選んでください</p>
+  </div>
+
+  <div class="row justify-content-center g-4">
+
+    <!-- 投稿する -->
+    <div class="col-md-4">
+      <div class="card shadow-sm p-4 text-center h-100">
+        <h5 class="fw-bold mb-3">✍️ レシピを投稿</h5>
+        <p class="text-muted">新しいレシピを作成します</p>
+
+        <%= link_to "投稿する",
+          new_recipe_path,
+          class: "btn btn-outline-warning rounded-pill px-4 mt-auto"  %>
+      </div>
+    </div>
+
+    <!-- 投稿一覧 -->
+    <div class="col-md-4">
+      <div class="card shadow-sm p-4 text-center h-100">
+        <h5 class="fw-bold mb-3">📖 投稿したレシピ</h5>
+        <p class="text-muted">自分のレシピを確認できます</p>
+
+        <%= link_to "一覧を見る",
+          my_recipes_recipes_path,
+          class: "btn btn-outline-warning rounded-pill px-4 mt-auto" %>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="text-center mt-5">
+    <%= link_to "ホームに戻る", dashboard_path,
+      class: "btn btn-secondary px-4 rounded-pill" %>
+  </div>
+</div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -22,6 +22,12 @@
       </div>
 
       <div class="mb-3 text-start">
+        <%= f.label :nickname,"ニックネーム" %>
+        <%= f.text_field :nickname,class:"form-control" %>
+      </div>
+
+
+      <div class="mb-3 text-start">
         <%= f.label :email,"メールアドレス" %>
         <%= f.email_field :email,class:"form-control" %>
       </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -19,35 +19,47 @@ ja:
         activity_level: "活動レベル"
         allergies: "アレルギー"
         breed: "犬種"
+
+      recipe:
+        name: "レシピ名"
+        description: "対象のわんちゃん"
+        instructions: "作り方"
+        nutrition_note: "栄養のポイント"
+        age_stage: "年齢ステージ"
+        body_type: "体型"
+        activity_level: "活動レベル"
+        ingredients_json: "材料"
     
-  enums:
-    dog:
-      age_stage:
-        puppy: "子犬"
-        adult: "成犬"
-        senior: "シニア"
-      size:
-        small: "小型犬"
-        medium: "中型犬"
-        large: "大型犬"
-      body_type:
-        thin: "痩せ型"
-        normal: "標準"
-        overweight: "肥満"
-      activity_level:
-        low: "穏やか"
-        medium: "普通"
-        high: "活発"
-      allergy:
-        牛肉: 牛肉
-        鶏肉: 鶏肉
-        豚肉: 豚肉
-        牛乳: 牛乳
-        チーズ: チーズ
-        ヨーグルト: ヨーグルト
-        卵: 卵
-        鹿肉: 鹿肉
-        納豆(大豆): 納豆(大豆)
-        鮭: 鮭
-        マグロ: マグロ
-        タラ: タラ
+    enums:
+      dog:
+        age_stage:
+          puppy: "子犬"
+          adult: "成犬"
+          senior: "シニア"
+        size:
+          small: "小型犬"
+          medium: "中型犬"
+          large: "大型犬"
+        body_type:
+          thin: "痩せ型"
+          normal: "標準"
+          overweight: "肥満"
+        activity_level:
+          low: "穏やか"
+          medium: "普通"
+          high: "活発"
+        allergy:
+          牛肉: 牛肉
+          鶏肉: 鶏肉
+          豚肉: 豚肉
+          牛乳: 牛乳
+          チーズ: チーズ
+          ヨーグルト: ヨーグルト
+          卵: 卵
+          鹿肉: 鹿肉
+          納豆(大豆): 納豆(大豆)
+          鮭: 鮭
+          マグロ: マグロ
+          タラ: タラ
+    
+ 

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -20,34 +20,34 @@ ja:
         allergies: "アレルギー"
         breed: "犬種"
     
-    enums:
-      dog:
-        age_stage:
-          puppy: "子犬"
-          adult: "成犬"
-          senior: "シニア"
-        size:
-          small: "小型犬"
-          medium: "中型犬"
-          large: "大型犬"
-        body_type:
-          thin: "痩せ型"
-          normal: "標準"
-          overweight: "肥満"
-        activity_level:
-          low: "穏やか"
-          medium: "普通"
-          high: "活発"
-        allergy:
-          牛肉: 牛肉
-          鶏肉: 鶏肉
-          豚肉: 豚肉
-          牛乳: 牛乳
-          チーズ: チーズ
-          ヨーグルト: ヨーグルト
-          卵: 卵
-          鹿肉: 鹿肉
-          納豆(大豆): 納豆(大豆)
-          鮭: 鮭
-          マグロ: マグロ
-          タラ: タラ
+  enums:
+    dog:
+      age_stage:
+        puppy: "子犬"
+        adult: "成犬"
+        senior: "シニア"
+      size:
+        small: "小型犬"
+        medium: "中型犬"
+        large: "大型犬"
+      body_type:
+        thin: "痩せ型"
+        normal: "標準"
+        overweight: "肥満"
+      activity_level:
+        low: "穏やか"
+        medium: "普通"
+        high: "活発"
+      allergy:
+        牛肉: 牛肉
+        鶏肉: 鶏肉
+        豚肉: 豚肉
+        牛乳: 牛乳
+        チーズ: チーズ
+        ヨーグルト: ヨーグルト
+        卵: 卵
+        鹿肉: 鹿肉
+        納豆(大豆): 納豆(大豆)
+        鮭: 鮭
+        マグロ: マグロ
+        タラ: タラ

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -32,3 +32,8 @@ ja:
       success: ブックマークしました
     destroy:
       success: ブックマークを外しました
+  admin:
+    recipes:
+      actions:
+        approve: レシピを承認
+        reject: レシピを却下

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,11 @@ Rails.application.routes.draw do
 
     # 管理者画面
     namespace :admin do
-    resources :recipes, only: [ :index, :show, :update ]
-    get "dashboard", to: "dashboard#index"
+    resources :recipes, only: [ :index, :show, :update ] do
+      collection do
+        get :published  # 承認済みレシピ一覧
+      end
+      get "dashboard", to: "dashboard#index"
   end
+end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,8 @@ Rails.application.routes.draw do
     collection do
       get :select_dog  # 愛犬選択画面(レシピ閲覧用)
       get :bookmarks   # ブックマーク
+      get :my_recipes   # マイレシピ
+      get :select_action
       post :confirm  # レシピ公開前の確認画面
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,10 +42,11 @@ Rails.application.routes.draw do
   end
 
   # レシピ
-  resources :recipes, only: [ :index, :show ] do
+  resources :recipes, only: [ :new, :create, :index, :show ] do
     collection do
       get :select_dog  # 愛犬選択画面(レシピ閲覧用)
       get :bookmarks   # ブックマーク
+      post :confirm  # レシピ公開前の確認画面
     end
   end
 

--- a/db/migrate/20260404091013_add_user_to_recipes.rb
+++ b/db/migrate/20260404091013_add_user_to_recipes.rb
@@ -1,0 +1,5 @@
+class AddUserToRecipes < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :recipes, :user, foreign_key: true, null: true
+  end
+end

--- a/db/migrate/20260404101029_add_nickname_to_users.rb
+++ b/db/migrate/20260404101029_add_nickname_to_users.rb
@@ -1,0 +1,5 @@
+class AddNicknameToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :nickname, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_04_091013) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_04_101029) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -68,6 +68,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_04_091013) do
     t.string "last_name"
     t.datetime "deleted_at"
     t.boolean "admin", default: false, null: false
+    t.string "nickname"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_02_060552) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_04_091013) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -53,6 +53,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_02_060552) do
     t.datetime "updated_at", null: false
     t.integer "status", default: 0, null: false
     t.json "ingredients_json"
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_recipes_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -74,4 +76,5 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_02_060552) do
   add_foreign_key "bookmarks", "recipes"
   add_foreign_key "bookmarks", "users"
   add_foreign_key "dogs", "users"
+  add_foreign_key "recipes", "users"
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     sequence(:email) { |n| "test#{n}@example.com" }
     password { "password" }
     password_confirmation { "password" }
+    nickname { "テストニックネーム" }
   end
 end

--- a/spec/models/dog_spec.rb
+++ b/spec/models/dog_spec.rb
@@ -46,23 +46,31 @@ RSpec.describe Dog, type: :model do
       )
 
       safe_recipe = create(:recipe,
-        ingredients: "魚"
+        ingredients_json: {
+          "medium" => [
+            { "name" => "魚", "amount" => 100, "unit" => "g" }
+         ]
+        }
       )
 
       ng_recipe = create(:recipe,
-        ingredients: "鶏肉"
+        ingredients_json: {
+          "medium" => [
+            { "name" => "鶏肉", "amount" => 100, "unit" => "g" }
+          ]
+        }
       )
 
-      result = dog.recommended_recipes
+  result = dog.recommended_recipes
 
-      expect(result).to include(safe_recipe)
-      expect(result).not_to include(ng_recipe)
-    end
+  expect(result).to include(safe_recipe)
+  expect(result).not_to include(ng_recipe)
+end
 
     it "最大5件返す" do
       dog = create(:dog, age_stage: :adult, body_type: :normal, activity_level: :medium)
 
-      create_list(:recipe, 5,
+      create_list(:recipe, 6,
         age_stage: :adult,
         body_type: :normal,
         activity_level: :medium,


### PR DESCRIPTION
**■ 実装内容**

1. レシピ投稿機能
レシピ投稿フォームを作成
確認画面（confirm）を挟んだ投稿フローを実装
材料は ingredients_json 形式で管理
入力内容を保持したまま修正できるよう改善

2. バリデーション強化
以下の必須項目を追加
レシピ名
対象のわんちゃん（description）
作り方
栄養ポイント
年齢 / 体型 / 運動量
材料は「1つ以上必須」のカスタムバリデーションを追加
未入力時にエラーメッセージを表示

3. ステータス管理機能
Recipe に status カラムを追加
draft（下書き）
published（公開）
rejected（却下）
投稿時は自動で draft に設定

4. 管理者承認機能
管理画面から以下の操作を実装
承認 → published
却下 → rejected
ボタンの値に応じてステータスを更新

5. 表示制御
未承認レシピは一般ユーザーに非表示
以下の場合のみ閲覧可能：
公開済み（published）
管理者
投稿者本人

6. レシピ一覧の分岐導線
「レシピ投稿」から以下へ分岐する画面を追加
新規投稿
自分の投稿一覧（my_recipes）

7. 材料入力UI改善
材料の動的追加機能（JS）を実装
削除ボタンを追加
confirm → 戻る時に入力内容を保持

8. 犬情報に応じたレシピ調整
犬の情報（年齢・体型・運動量）から係数を計算
材料量を自動調整するロジックを実装

■ 修正・改善内容
confirm画面でのStrong Parametersエラー修正
i18nの翻訳キー不整合を修正
ingredients_jsonのHash/Array両対応
材料データ処理時のTypeError修正
管理者承認ボタンの分岐ロジック修正

■ 動作確認
レシピ投稿 → 確認 → 保存できること
未承認レシピが一覧に表示されないこと
管理者が承認すると公開されること
投稿者は自分の下書きを閲覧できること
犬の条件に応じてレシピがフィルタされること