### PR TITLE
tagを利用したアレルギー除外

### DIFF
--- a/app/models/dog.rb
+++ b/app/models/dog.rb
@@ -55,7 +55,7 @@ class Dog < ApplicationRecord
     recipes = Recipe.published.to_a
 
     # アレルギー取得
-    allergies_list = parse_allergies  
+    allergies_list = allergies || []
 
     # タグに変換
     allergy_tags = allergies_list.map { |a| ALLERGY_MAP[a] }.compact
@@ -87,26 +87,12 @@ class Dog < ApplicationRecord
   def allergies_i18n
     return "なし" if allergies.blank?
 
-    list = allergies.is_a?(String) ? [allergies] : allergies
-
-    list.map do |allergy|
-      I18n.t("enums.dog.allergy.#{allergy}", default: allergy)
-    end.join(", ")
-  end
+    allergies.map do |allergy|
+    I18n.t("enums.dog.allergy.#{allergy}", default: allergy)
+  end.join(", ")
+end
 
   private
-
-  # アレルギーを配列に変換
-  def parse_allergies
-    return [] if allergies.blank?
-
-    # 文字列の場合はカンマで分割、配列の場合はそのまま
-    if allergies.is_a?(String)
-      allergies.split(",").map(&:strip)
-    else
-      allergies
-    end
-  end
 
   # レシピがアレルゲンを含むか確認
   def recipe_has_allergen?(recipe, allergy_tags)

--- a/app/models/dog.rb
+++ b/app/models/dog.rb
@@ -71,7 +71,7 @@ class Dog < ApplicationRecord
       score += 1 if recipe.age_stage == age_stage
       score += 1 if recipe.body_type == body_type
       score += 1 if recipe.activity_level == activity_level
-      [recipe, score]
+      [ recipe, score ]
     end
 
     # 上位取得
@@ -96,13 +96,13 @@ end
 
   # レシピがアレルゲンを含むか確認
   def recipe_has_allergen?(recipe, allergy_tags)
-    # 全サイズの材料を取得
-    ingredients = recipe.ingredients_json.values.flatten
+  # ingredients_json が nil の場合は false を返す
+  return false if recipe.ingredients_json.blank?
 
-    # 材料のタグとアレルギータグを照合
-    ingredients.any? do |ingredient|
-      ingredient_tags = ingredient["tags"] || []
-      (allergy_tags & ingredient_tags).any?  # 共通要素があるか?
-    end
+  ingredients = recipe.ingredients_json.values.flatten
+
+  ingredients.any? do |ingredient|
+    allergies.any? { |allergy| ingredient["name"].to_s.include?(allergy) }
   end
+end
 end

--- a/app/models/dog.rb
+++ b/app/models/dog.rb
@@ -1,7 +1,7 @@
 class Dog < ApplicationRecord
   belongs_to :user, optional: true
 
-  # アレルギー情報（表示用）
+  # アレルギー情報(表示用)
   ALLERGIES = [
     "牛肉", "鶏肉", "豚肉", "牛乳", "チーズ", "ヨーグルト",
     "卵", "鹿肉", "納豆(大豆)", "鮭", "マグロ", "タラ"
@@ -26,7 +26,6 @@ class Dog < ApplicationRecord
     "魚" => "fish",
     "米" => "rice",
     "雑穀米" => "grain"
-
   }.freeze
 
   enum :size, { small: 0, medium: 1, large: 2 }, prefix: true
@@ -48,41 +47,23 @@ class Dog < ApplicationRecord
   validates :body_type, presence: true
   validates :activity_level, presence: true
   validates :avatar,
-  content_type: { in: %w[image/png image/jpeg image/webp] },
-  size: { less_than: 5.megabytes, message: "画像は5MB以下にしてください" }
+            content_type: { in: %w[image/png image/jpeg image/webp] },
+            size: { less_than: 5.megabytes, message: "画像は5MB以下にしてください" }
 
+  # 推奨レシピを取得
   def recommended_recipes
     recipes = Recipe.published.to_a
 
-    allergies_list = allergies
+    # アレルギー取得
+    allergies_list = parse_allergies  
 
-    if allergies_list.is_a?(String)
-      begin
-        allergies_list = JSON.parse(allergies_list)
-      rescue
-        allergies_list = [ allergies_list ]
-      end
+    # タグに変換
+    allergy_tags = allergies_list.map { |a| ALLERGY_MAP[a] }.compact
+
+    # アレルギーを含むレシピを除外
+    recipes = recipes.reject do |recipe|
+      recipe_has_allergen?(recipe, allergy_tags)
     end
-
-
-    #  アレルギー除外
-    if allergies_list.present?
-      recipes = recipes.reject do |recipe|
-        next true if recipe.ingredients_json.blank?
-
-        ingredients = recipe.ingredients_json.values.flatten
-
-        allergies_list.any? do |a|
-            tag = ALLERGY_MAP[a]
-
-      ingredients.any? do |ing|
-        ing["name"]&.include?(a) ||
-        (tag && ing["tags"]&.include?(tag))
-          end
-        end
-      end
-    end
-
 
     # スコアリング
     scored = recipes.map do |recipe|
@@ -90,7 +71,7 @@ class Dog < ApplicationRecord
       score += 1 if recipe.age_stage == age_stage
       score += 1 if recipe.body_type == body_type
       score += 1 if recipe.activity_level == activity_level
-      [ recipe, score ]
+      [recipe, score]
     end
 
     # 上位取得
@@ -100,15 +81,42 @@ class Dog < ApplicationRecord
                     .take(20)
 
     top_recipes.sample(5)
-   end
+  end
 
+  # アレルギー情報を日本語で表示
   def allergies_i18n
     return "なし" if allergies.blank?
 
-    list = allergies.is_a?(String) ? [ allergies ] : allergies
+    list = allergies.is_a?(String) ? [allergies] : allergies
 
     list.map do |allergy|
-    I18n.t("enums.dog.allergy.#{allergy}", default: allergy)
-  end.join(", ")
+      I18n.t("enums.dog.allergy.#{allergy}", default: allergy)
+    end.join(", ")
+  end
+
+  private
+
+  # アレルギーを配列に変換
+  def parse_allergies
+    return [] if allergies.blank?
+
+    # 文字列の場合はカンマで分割、配列の場合はそのまま
+    if allergies.is_a?(String)
+      allergies.split(",").map(&:strip)
+    else
+      allergies
+    end
+  end
+
+  # レシピがアレルゲンを含むか確認
+  def recipe_has_allergen?(recipe, allergy_tags)
+    # 全サイズの材料を取得
+    ingredients = recipe.ingredients_json.values.flatten
+
+    # 材料のタグとアレルギータグを照合
+    ingredients.any? do |ingredient|
+      ingredient_tags = ingredient["tags"] || []
+      (allergy_tags & ingredient_tags).any?  # 共通要素があるか?
+    end
   end
 end

--- a/app/services/image_processor.rb
+++ b/app/services/image_processor.rb
@@ -22,7 +22,7 @@ class ImageProcessor
       # 一時ファイルに書き込み
       image.write(temp_file.path)
 
-      # ファイルポインタを先頭に戻す（これは必要）
+      # ファイルポインタを先頭に戻す
       temp_file.rewind
 
       # 返す

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -14,12 +14,13 @@
     <hr class="my-4">
 
     <!-- 材料 -->
-<div class="mb-4">
-  <div class="d-flex justify-content-between align-items-center mb-3">
-    <h5 class="fw-bold mb-0" style="color: #f4a300;">
-      🥕 材料
-    </h5>
-    <!-- ブックマークボタン（ログインユーザーのみ表示） -->
+    <div class="mb-4">
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h5 class="fw-bold mb-0" style="color: #f4a300;">
+          🥕 材料
+        </h5>
+        
+        <!-- ブックマークボタン（ログインユーザーのみ表示） -->
         <% if logged_in? %>
           <div>
             <% if @bookmark.present? %>
@@ -41,161 +42,29 @@
         <% end %>
       </div>
   
-  <% if @recipe.json_format? %>
-    <!-- JSON形式の場合 -->
-    
-    <!-- 犬情報の表示 -->
-    <% if @dog.present? %>
-      <div class="alert alert-info mb-3">
-        <strong><%= @dog.name %></strong> ちゃん用に調整されています
-        (サイズ: <%= @dog.size_i18n %> / 
-         年齢: <%= @dog.age_stage_i18n %> / 
-         体型: <%= @dog.body_type_i18n %> /
-         運動量: <%= @dog.activity_level_i18n %>)
-      </div>
-
-      <!-- ✅ 犬のサイズに応じた材料のみを表示 -->
-      <div class="bg-light p-3 rounded-3 mt-3">
-        <ul class="list-unstyled mb-0">
-          <% @adjusted_ingredients.each do |ingredient| %>
-            <li class="mb-2">
-              <strong><%= ingredient[:name] %>:</strong> 
-              <%= ingredient[:amount] %><%= ingredient[:unit] %>
-            </li>
-          <% end %>
-        </ul>
-      </div>
-
-    <% else %>
-      <!-- ✅ 犬が登録されていない場合は全てのサイズのタブを表示 -->
-      <!-- サイズ選択タブ -->
-      <ul class="nav nav-tabs" id="ingredientsTab" role="tablist">
-        <li class="nav-item" role="presentation">
-          <button class="nav-link active" id="small-tab" data-bs-toggle="tab" data-bs-target="#small" type="button" role="tab">
-            小型犬（〜5kg）
-          </button>
-        </li>
-        <li class="nav-item" role="presentation">
-          <button class="nav-link" id="medium-tab" data-bs-toggle="tab" data-bs-target="#medium" type="button" role="tab">
-            中型犬（6〜15kg）
-          </button>
-        </li>
-        <li class="nav-item" role="presentation">
-          <button class="nav-link" id="large-tab" data-bs-toggle="tab" data-bs-target="#large" type="button" role="tab">
-            大型犬（16kg〜）
-          </button>
-        </li>
-      </ul>
-
-      <!-- タブコンテンツ -->
-      <div class="tab-content" id="ingredientsTabContent">
-        <!-- 小型犬 -->
-        <div class="tab-pane fade show active" id="small" role="tabpanel">
-          <div class="bg-light p-3 rounded-3 mt-3">
-            <ul class="list-unstyled mb-0">
-              <% @adjusted_ingredients_small.each do |ingredient| %>
-                <li class="mb-2">
-                  <strong><%= ingredient[:name] %>:</strong> 
-                  <%= ingredient[:amount] %><%= ingredient[:unit] %>
-                </li>
-              <% end %>
-            </ul>
-          </div>
+      <!-- 犬情報の表示 -->
+      <% if @dog.present? %>
+        <div class="alert alert-info mb-3">
+          <strong><%= @dog.name %></strong> ちゃん用に調整されています
+          (サイズ: <%= @dog.size_i18n %> / 
+           年齢: <%= @dog.age_stage_i18n %> / 
+           体型: <%= @dog.body_type_i18n %> /
+           運動量: <%= @dog.activity_level_i18n %>)
         </div>
 
-        <!-- 中型犬 -->
-        <div class="tab-pane fade" id="medium" role="tabpanel">
-          <div class="bg-light p-3 rounded-3 mt-3">
-            <ul class="list-unstyled mb-0">
-              <% @adjusted_ingredients_medium.each do |ingredient| %>
-                <li class="mb-2">
-                  <strong><%= ingredient[:name] %>:</strong> 
-                  <%= ingredient[:amount] %><%= ingredient[:unit] %>
-                </li>
-              <% end %>
-            </ul>
-          </div>
+        <!-- 犬のサイズに応じた材料を表示 -->
+        <div class="bg-light p-3 rounded-3 mt-3">
+          <ul class="list-unstyled mb-0">
+            <% @adjusted_ingredients.each do |ingredient| %>
+  <li class="mb-2">
+    <strong><%= ingredient[:name] || ingredient["name"] %>:</strong> 
+    <%= ingredient[:amount] || ingredient["amount"] %><%= ingredient[:unit] || ingredient["unit"] %>
+  </li>
+<% end %>
+          </ul>
         </div>
-
-        <!-- 大型犬 -->
-        <div class="tab-pane fade" id="large" role="tabpanel">
-          <div class="bg-light p-3 rounded-3 mt-3">
-            <ul class="list-unstyled mb-0">
-              <% @adjusted_ingredients_large.each do |ingredient| %>
-                <li class="mb-2">
-                  <strong><%= ingredient[:name] %>:</strong> 
-                  <%= ingredient[:amount] %><%= ingredient[:unit] %>
-                </li>
-              <% end %>
-            </ul>
-          </div>
-        </div>
-      </div>
-    <% end %>
-
-  <% else %>
-    <!-- TEXT形式の場合 -->
-    
-    <!-- 犬情報の表示 -->
-    <% if @dog.present? %>
-      <div class="alert alert-info mb-3">
-        <strong><%= @dog.name %></strong> ちゃん用に調整されています
-        (サイズ: <%= @dog.size_i18n %>)
-      </div>
-
-      <!-- ✅ 犬のサイズに応じた材料のみを表示 -->
-      <div class="bg-light p-3 rounded-3 mt-3">
-        <%= simple_format(@recipe.ingredients_for_size(@dog.size.to_sym)) %>
-      </div>
-
-    <% else %>
-      <!-- ✅ 犬が登録されていない場合は全てのサイズのタブを表示 -->
-      <!-- サイズ選択タブ -->
-      <ul class="nav nav-tabs" id="ingredientsTab" role="tablist">
-        <li class="nav-item" role="presentation">
-          <button class="nav-link active" id="small-tab" data-bs-toggle="tab" data-bs-target="#small" type="button" role="tab">
-            小型犬（〜5kg）
-          </button>
-        </li>
-        <li class="nav-item" role="presentation">
-          <button class="nav-link" id="medium-tab" data-bs-toggle="tab" data-bs-target="#medium" type="button" role="tab">
-            中型犬（6〜15kg）
-          </button>
-        </li>
-        <li class="nav-item" role="presentation">
-          <button class="nav-link" id="large-tab" data-bs-toggle="tab" data-bs-target="#large" type="button" role="tab">
-            大型犬（16kg〜）
-          </button>
-        </li>
-      </ul>
-
-      <!-- タブコンテンツ -->
-      <div class="tab-content" id="ingredientsTabContent">
-        <!-- 小型犬 -->
-        <div class="tab-pane fade show active" id="small" role="tabpanel">
-          <div class="bg-light p-3 rounded-3 mt-3">
-            <%= simple_format(@recipe.ingredients_for_size(:small)) %>
-          </div>
-        </div>
-
-        <!-- 中型犬 -->
-        <div class="tab-pane fade" id="medium" role="tabpanel">
-          <div class="bg-light p-3 rounded-3 mt-3">
-            <%= simple_format(@recipe.ingredients_for_size(:medium)) %>
-          </div>
-        </div>
-
-        <!-- 大型犬 -->
-        <div class="tab-pane fade" id="large" role="tabpanel">
-          <div class="bg-light p-3 rounded-3 mt-3">
-            <%= simple_format(@recipe.ingredients_for_size(:large)) %>
-          </div>
-        </div>
-      </div>
-    <% end %>
-
-  <% end %>
-</div>
+      <% end %>
+    </div>
 
     <!-- 作り方 -->
     <div class="mb-4">
@@ -217,47 +86,50 @@
       </div>
     </div>
 
+    <!-- SNSシェアボタン -->
     <div class="text-center mt-4">
-  <% share_text = "#{@recipe.name} をチェック！🐶🍽️" %>
-  <% share_url = recipe_url(@recipe) %>
-  <% hashtags = "犬ごはん,手作り犬ごはん" %>
+      <% share_text = "#{@recipe.name} をチェック！🐶🍽️" %>
+      <% share_url = recipe_url(@recipe) %>
+      <% hashtags = "犬ごはん,手作り犬ごはん" %>
 
-  <%= link_to "🐾 Xでシェアする",
-  "https://twitter.com/intent/tweet?text=#{CGI.escape(share_text)}&url=#{CGI.escape(share_url)}&hashtags=#{hashtags}",
-  target: "_blank",
-  rel: "noopener",
-  class: "btn px-4 py-2",
-  style: "
-    background-color: #444;
-    color: white;
-    border-radius: 30px;
-    font-weight: bold;
-    transition: 0.2s;
-  ",
-  onmouseover: "this.style.backgroundColor='#666'",
-  onmouseout: "this.style.backgroundColor='#444'" %>
-  </div>
+      <%= link_to "🐾 Xでシェアする",
+        "https://twitter.com/intent/tweet?text=#{CGI.escape(share_text)}&url=#{CGI.escape(share_url)}&hashtags=#{hashtags}",
+        target: "_blank",
+        rel: "noopener",
+        class: "btn px-4 py-2",
+        style: "
+          background-color: #444;
+          color: white;
+          border-radius: 30px;
+          font-weight: bold;
+          transition: 0.2s;
+        ",
+        onmouseover: "this.style.backgroundColor='#666'",
+        onmouseout: "this.style.backgroundColor='#444'" %>
+    </div>
 
-<div class="text-center mt-3">
-  <button onclick="copyToClipboard()" 
-    class="btn px-4 py-2"
-    style="
-      background-color: #f4a300;
-      color: white;
-      border-radius: 30px;
-      font-weight: bold;
-    ">
-    📋 URLをコピー
-  </button>
-</div>
+    <!-- URLコピーボタン -->
+    <div class="text-center mt-3">
+      <button onclick="copyToClipboard()" 
+        class="btn px-4 py-2"
+        style="
+          background-color: #f4a300;
+          color: white;
+          border-radius: 30px;
+          font-weight: bold;
+        ">
+        📋 URLをコピー
+      </button>
+    </div>
 
-<script>
-function copyToClipboard() {
-  const url = "<%= recipe_url(@recipe) %>";
-  navigator.clipboard.writeText(url);
-  alert("URLをコピーしました！Instagramなどでシェアしてね🐶📸");
-}
-</script>
+    <script>
+    function copyToClipboard() {
+      const url = "<%= recipe_url(@recipe) %>";
+      navigator.clipboard.writeText(url);
+      alert("URLをコピーしました！Instagramなどでシェアしてね🐶📸");
+    }
+    </script>
+
     <!-- 戻るボタン -->
     <div class="text-center mt-4">
       <%= link_to "← 戻る",

--- a/db/migrate/20260412143502_change_allergies_type_in_dogs_fixed.rb
+++ b/db/migrate/20260412143502_change_allergies_type_in_dogs_fixed.rb
@@ -2,11 +2,11 @@ class ChangeAllergiesTypeInDogsFixed < ActiveRecord::Migration[7.0]
   def up
     # ステップ1: 一時カラムを追加
     add_column :dogs, :allergies_temp, :string, array: true, default: []
-    
+
     # ステップ2: 既存データを配列に変換して一時カラムに保存
     Dog.find_each do |dog|
       next if dog.allergies.blank?
-      
+
       begin
         # JSON文字列を配列に変換
         allergies_array = JSON.parse(dog.allergies)
@@ -16,26 +16,26 @@ class ChangeAllergiesTypeInDogsFixed < ActiveRecord::Migration[7.0]
         dog.update_column(:allergies_temp, [])
       end
     end
-    
+
     # ステップ3: 元のカラムを削除
     remove_column :dogs, :allergies
-    
+
     # ステップ4: 一時カラムの名前を変更
     rename_column :dogs, :allergies_temp, :allergies
   end
-  
+
   def down
     # ロールバック処理
     add_column :dogs, :allergies_temp, :text
-    
+
     Dog.find_each do |dog|
       next if dog.allergies.blank?
-      
+
       # 配列をJSON文字列に変換
       allergies_json = dog.allergies.to_json
       dog.update_column(:allergies_temp, allergies_json)
     end
-    
+
     remove_column :dogs, :allergies
     rename_column :dogs, :allergies_temp, :allergies
   end

--- a/db/migrate/20260412143502_change_allergies_type_in_dogs_fixed.rb
+++ b/db/migrate/20260412143502_change_allergies_type_in_dogs_fixed.rb
@@ -1,0 +1,42 @@
+class ChangeAllergiesTypeInDogsFixed < ActiveRecord::Migration[7.0]
+  def up
+    # ステップ1: 一時カラムを追加
+    add_column :dogs, :allergies_temp, :string, array: true, default: []
+    
+    # ステップ2: 既存データを配列に変換して一時カラムに保存
+    Dog.find_each do |dog|
+      next if dog.allergies.blank?
+      
+      begin
+        # JSON文字列を配列に変換
+        allergies_array = JSON.parse(dog.allergies)
+        dog.update_column(:allergies_temp, allergies_array)
+      rescue JSON::ParserError
+        # JSON解析エラーの場合は空配列を設定
+        dog.update_column(:allergies_temp, [])
+      end
+    end
+    
+    # ステップ3: 元のカラムを削除
+    remove_column :dogs, :allergies
+    
+    # ステップ4: 一時カラムの名前を変更
+    rename_column :dogs, :allergies_temp, :allergies
+  end
+  
+  def down
+    # ロールバック処理
+    add_column :dogs, :allergies_temp, :text
+    
+    Dog.find_each do |dog|
+      next if dog.allergies.blank?
+      
+      # 配列をJSON文字列に変換
+      allergies_json = dog.allergies.to_json
+      dog.update_column(:allergies_temp, allergies_json)
+    end
+    
+    remove_column :dogs, :allergies
+    rename_column :dogs, :allergies_temp, :allergies
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_05_122021) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_12_143502) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -61,10 +61,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_05_122021) do
     t.integer "weight"
     t.integer "body_type"
     t.integer "activity_level"
-    t.text "allergies"
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "allergies", default: [], array: true
     t.index ["user_id"], name: "index_dogs_on_user_id"
   end
 

--- a/spec/factories/recipes.rb
+++ b/spec/factories/recipes.rb
@@ -9,5 +9,22 @@ FactoryBot.define do
     instructions { "焼く" }
     nutrition_note { "栄養あり" }
     status { :published }
+
+
+    ingredients_json do
+      {
+        "small" => [
+          { "name" => "魚", "amount" => 50, "unit" => "g" }
+        ],
+        "medium" => [
+          { "name" => "魚", "amount" => 100, "unit" => "g" }
+        ],
+        "large" => [
+          { "name" => "魚", "amount" => 150, "unit" => "g" }
+        ]
+      }
+    end
+
+    association :user
   end
 end

--- a/spec/models/dog_spec.rb
+++ b/spec/models/dog_spec.rb
@@ -1,68 +1,129 @@
 require 'rails_helper'
 
 RSpec.describe Dog, type: :model do
-  it "有効な犬は保存できる" do
-    dog = build(:dog)
-    expect(dog).to be_valid
+  # バリデーションのテスト
+  describe "バリデーション" do
+    it "有効な犬は保存できる" do
+      dog = build(:dog)
+      expect(dog).to be_valid
+    end
+
+    it "nameがないと無効" do
+      dog = build(:dog, name: nil)
+      expect(dog).to be_invalid
+    end
+
+    it "sizeがないと無効" do
+      dog = build(:dog, size: nil)
+      expect(dog).to be_invalid
+    end
+
+    it "age_stageがないと無効" do
+      dog = build(:dog, age_stage: nil)
+      expect(dog).to be_invalid
+    end
   end
 
-  it "nameがないと無効" do
-    dog = build(:dog, name: nil)
-    expect(dog).to be_invalid
-  end
+  # 画像添付のテスト
+  describe "画像添付" do
+    it "画像を添付できる" do
+      dog = build(:dog)
 
-  it "sizeがないと無効" do
-    dog = build(:dog, size: nil)
-    expect(dog).to be_invalid
-  end
-
-  it "age_stageがないと無効" do
-    dog = build(:dog, age_stage: nil)
-    expect(dog).to be_invalid
-  end
-
-  it "画像を添付できる" do
-    dog = build(:dog)
-
-    file = fixture_file_upload(
-    Rails.root.join("spec/fixtures/files/test_image.png"),
-    "image/png"
-  )
-
-  dog.avatar.attach(file)
-
-    expect(dog.avatar).to be_attached
-  end
-
-  it "複数の犬がそれぞれ画像を持てる" do
-  user = create(:user)
-  dogs = create_list(:dog, 2, user: user)
-
-  dogs.each_with_index do |dog, i|
-    dog.avatar.attach(
-      io: File.open(Rails.root.join("spec/fixtures/files/test_dog.jpg")),
-      filename: "dog#{i}.jpg",
-      content_type: "image/jpeg"
-    )
-  end
-
-  expect(dogs.all? { |d| d.avatar.attached? }).to be true
-  end
-
-  describe "#recommended_recipes" do
-    it "条件に一致するレシピが返る" do
-      dog = create(:dog, age_stage: :adult, body_type: :normal, activity_level: :medium)
-
-      recipe = create(:recipe,
-        age_stage: :adult,
-        body_type: :normal,
-        activity_level: :medium,
+      file = fixture_file_upload(
+        Rails.root.join("spec/fixtures/files/test_image.png"),
+        "image/png"
       )
 
-      result = dog.recommended_recipes
+      dog.avatar.attach(file)
 
-      expect(result).to include(recipe)
+      expect(dog.avatar).to be_attached
     end
+
+    it "複数の犬がそれぞれ画像を持てる" do
+      user = create(:user)
+      dogs = create_list(:dog, 2, user: user)
+
+      dogs.each_with_index do |dog, i|
+        dog.avatar.attach(
+          io: File.open(Rails.root.join("spec/fixtures/files/test_dog.jpg")),
+          filename: "dog#{i}.jpg",
+          content_type: "image/jpeg"
+        )
+      end
+
+      expect(dogs.all? { |d| d.avatar.attached? }).to be true
+    end
+
+    it "webp形式で保存される" do
+      dog = build(:dog)
+
+      file = fixture_file_upload(
+        Rails.root.join('spec/fixtures/files/test_image.png'),
+        'image/png'
+      )
+
+      processed = ImageProcessor.process(file)
+
+      dog.avatar.attach(
+        io: processed,
+        filename: "processed.webp",
+        content_type: "image/webp"
+      )
+
+      dog.save!
+
+      expect(dog.avatar).to be_attached
+      expect(dog.avatar.blob.content_type).to eq("image/webp")
+    end
+  end
+
+  # アレルギー情報のテスト
+  describe "allergies（アレルギー情報）" do
+    it "配列として保存される" do
+      dog = create(:dog, allergies: [ "牛肉", "鶏肉" ])
+
+      # データベースから再取得
+      dog.reload
+
+      expect(dog.allergies).to eq([ "牛肉", "鶏肉" ])
+      expect(dog.allergies.class).to eq(Array)
+      expect(dog.allergies_i18n).to eq("牛肉, 鶏肉")
+    end
+
+    it "allergies_i18nは空の場合に'なし'を返す" do
+      dog = create(:dog, allergies: [])
+
+      expect(dog.allergies_i18n).to eq("なし")
+    end
+
+    it "allergiesがnilの場合も'なし'を返す" do
+      dog = create(:dog, allergies: nil)
+
+      expect(dog.allergies_i18n).to eq("なし")
+    end
+  end
+
+  # 推奨レシピのテスト
+  describe "#recommended_recipes" do
+    it "条件に一致するレシピが返る" do
+      dog = create(:dog, age_stage: :adult, body_type: :normal, activity_level: :medium, size: :medium)
+
+    recipe = create(:recipe,
+      age_stage: :adult,
+      body_type: :normal,
+      activity_level: :medium,
+      ingredients_json: {
+        "medium" => [
+          { "name" => "魚", "amount" => 100, "unit" => "g" }
+        ]
+      }
+    )
+
+    result = dog.recommended_recipes
+
+    expect(result).to include(recipe)
+  end
+
 
     it "アレルギー食材を含むレシピは除外される" do
       dog = create(:dog,
@@ -76,40 +137,47 @@ RSpec.describe Dog, type: :model do
       safe_recipe = create(:recipe,
         ingredients_json: {
           "medium" => [
-            { "name" => "魚", "amount" => 100, "unit" => "g" }
-         ]
+            { "name" => "魚", "amount" => 100, "unit" => "g", "tags" => [ "fish" ] }
+          ]
         }
       )
 
       ng_recipe = create(:recipe,
         ingredients_json: {
           "medium" => [
-            { "name" => "鶏肉", "amount" => 100, "unit" => "g" }
+            { "name" => "鶏肉", "amount" => 100, "unit" => "g", "tags" => [ "chicken" ] }
           ]
         }
       )
 
-  result = dog.recommended_recipes
-
-  expect(result).to include(safe_recipe)
-  expect(result).not_to include(ng_recipe)
-end
-
-    it "最大5件返す" do
-      dog = create(:dog, age_stage: :adult, body_type: :normal, activity_level: :medium)
-
-      create_list(:recipe, 6,
-        age_stage: :adult,
-        body_type: :normal,
-        activity_level: :medium,
-      )
-
       result = dog.recommended_recipes
 
-      expect(result.length).to be <= 5
+      expect(result).to include(safe_recipe)
+      expect(result).not_to include(ng_recipe)
     end
+
+    it "最大5件返す" do
+      dog = create(:dog, age_stage: :adult, body_type: :normal, activity_level: :medium, size: :medium)
+
+    create_list(:recipe, 6,
+      age_stage: :adult,
+      body_type: :normal,
+      activity_level: :medium,
+      ingredients_json: {
+        "medium" => [
+          { "name" => "魚", "amount" => 100, "unit" => "g" }
+        ]
+      }
+    )
+
+    result = dog.recommended_recipes
+
+    expect(result.length).to be <= 5
+  end
   end
 
+  # ユーザーとの関連のテスト
+  describe "ユーザーとの関連" do
     it "ユーザーは複数の犬を登録できる" do
       user = create(:user)
 
@@ -119,45 +187,20 @@ end
       expect(user.dogs.count).to eq(2)
     end
 
-   it "犬ごとに異なるレシピが返る" do
-   user = create(:user)
-  dog1 = create(:dog, user: user, age_stage: :puppy, body_type: :thin, activity_level: :low, size: :small)
-  dog2 = create(:dog, user: user, age_stage: :adult, body_type: :normal, activity_level: :medium, size: :medium)
+    it "犬ごとに異なるレシピが返る" do
+      user = create(:user)
+      dog1 = create(:dog, user: user, age_stage: :puppy, body_type: :thin, activity_level: :low, size: :small)
+      dog2 = create(:dog, user: user, age_stage: :adult, body_type: :normal, activity_level: :medium, size: :medium)
 
-  recipe1 = create(:recipe, age_stage: :puppy, body_type: :thin, activity_level: :low)
-  recipe2 = create(:recipe, age_stage: :adult, body_type: :normal, activity_level: :medium)
+      recipe1 = create(:recipe, age_stage: :puppy, body_type: :thin, activity_level: :low)
+      recipe2 = create(:recipe, age_stage: :adult, body_type: :normal, activity_level: :medium)
 
-  dog1_recipes = dog1.recommended_recipes
-  dog2_recipes = dog2.recommended_recipes
+      dog1_recipes = dog1.recommended_recipes
+      dog2_recipes = dog2.recommended_recipes
 
-  # ✅ スコアが高いレシピが含まれることを確認
-  expect(dog1_recipes).to include(recipe1)
-  expect(dog2_recipes).to include(recipe2)
-end
-
-describe 'avatar upload (webp変換)' do
-  let(:dog) { build(:dog) }
-
-  let(:file) do
-    fixture_file_upload(
-      Rails.root.join('spec/fixtures/files/test_image.png'),
-      'image/png'
-    )
+      # スコアが高いレシピが含まれることを確認
+      expect(dog1_recipes).to include(recipe1)
+      expect(dog2_recipes).to include(recipe2)
+    end
   end
-
-  it 'webp形式で保存される' do
-    processed = ImageProcessor.process(file)
-
-    dog.avatar.attach(
-      io: processed,
-      filename: "processed.webp",
-      content_type: "image/webp"
-    )
-
-    dog.save!
-
-    expect(dog.avatar).to be_attached
-    expect(dog.avatar.blob.content_type).to eq("image/webp")
-  end
-end
 end


### PR DESCRIPTION
## 概要
犬のアレルギー情報を活用したレシピ推薦機能を改善しました
## 変更内容
-  `Dog` モデルの `recommended_recipes` メソッドを改善
-  `ingredients_json` 内の `tags` を活用したアレルギー除外ロジックを実装
-  アレルギー食材のマッピング(`ALLERGY_MAP`)を追加
-  JSON 配列と文字列形式の両方に対応

## 変更ファイル
- `app/models/dog.rb`

## 確認方法

### 1. アレルギー除外の確認
1. 犬の登録画面でアレルギー情報を設定
   - 例: `["chicken", "beef"]` または `chicken,beef`
2. おすすめレシピページにアクセス
3. 鶏肉や牛肉を含むレシピが表示されないことを確認
4. 除外されたレシピの数を確認

### 2. アレルギー未設定の場合
1. アレルギー情報を設定していない犬でログイン
2. おすすめレシピページにアクセス
3. 全てのレシピが表示されることを確認
4. スコアリングが正常に動作していることを確認

### 3. 複数アレルギーの確認
1. 複数のアレルギー情報を設定
   - 例: `["chicken", "beef", "wheat"]`
2. おすすめレシピページにアクセス
3. 該当する食材を含むレシピが全て除外されることを確認
