### PR TITLE
ユーザー情報編集画面の追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,6 +30,21 @@ class UsersController < ApplicationController
     end
   end
 
+  def edit
+    @user = current_user
+  end
+
+  def update
+    @user = current_user
+
+    if @user.update(user_params)
+      redirect_to root_path, notice: "ユーザー情報を更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+
   private
 
     def user_params

--- a/app/views/homes/dashboard.html.erb
+++ b/app/views/homes/dashboard.html.erb
@@ -146,6 +146,17 @@
 
     <% end %>
 
+    <!-- ユーザー情報 -->
+    <%= render "homes/card",
+        icon: "bi-person",
+        title: "ユーザー情報",
+        text: "プロフィールやパスワードを変更" do %>
+
+    <%= link_to "情報を変更",
+        edit_user_path(current_user),
+        class: "btn btn-warning btn-lg" %>
+
+    <% end %>
 
     <!-- レシピ投稿 -->
     <%= render "homes/card",

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -21,6 +21,7 @@
         <%= f.email_field :email,class:"form-control" %>
       </div>
 
+    <% if @user.new_record? %>
       <div class="mb-3 text-start">
         <%= f.label :password,"パスワード" %>
         <%= f.password_field :password,class:"form-control" %>
@@ -30,6 +31,7 @@
         <%= f.label :password_confirmation,"パスワード確認" %>
         <%= f.password_field :password_confirmation,class:"form-control" %>
       </div>
+    <% end %>
 
       <%= f.submit "登録する",class:"primary-button" %>
 

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,37 @@
+<%= form_with model:@user, local:true do |f| %>
+
+      <div class="mb-3 text-start">
+        <%= f.label :last_name,"姓" %>
+        <%= f.text_field :last_name,class:"form-control" %>
+      </div>
+
+      <div class="mb-3 text-start">
+        <%= f.label :first_name,"名" %>
+        <%= f.text_field :first_name,class:"form-control" %>
+      </div>
+
+      <div class="mb-3 text-start">
+        <%= f.label :nickname,"ニックネーム" %>
+        <%= f.text_field :nickname,class:"form-control" %>
+      </div>
+
+
+      <div class="mb-3 text-start">
+        <%= f.label :email,"メールアドレス" %>
+        <%= f.email_field :email,class:"form-control" %>
+      </div>
+
+      <div class="mb-3 text-start">
+        <%= f.label :password,"パスワード" %>
+        <%= f.password_field :password,class:"form-control" %>
+      </div>
+
+      <div class="mb-3 text-start">
+        <%= f.label :password_confirmation,"パスワード確認" %>
+        <%= f.password_field :password_confirmation,class:"form-control" %>
+      </div>
+
+      <%= f.submit "登録する",class:"primary-button" %>
+
+    <% end %>
+

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,11 @@
+<div class="top-container">
+
+  <h1 class="accent">ユーザー情報編集</h1>
+  <p class="sub-text">登録情報を変更できます</p>
+
+  <div class="mt-4" style="max-width:400px;margin:auto;">
+    <%= render "form", submit_text: "更新する" %>
+  </div>
+
+  <%= link_to "戻る", root_path, class:"secondary-button" %>
+</div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -7,5 +7,6 @@
     <%= render "form", submit_text: "更新する" %>
   </div>
 
+  <%= link_to "パスワードを変更", new_password_reset_path, class:"secondary-button"%>
   <%= link_to "戻る", root_path, class:"secondary-button" %>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,51 +3,9 @@
   <h1 class="accent">新規登録</h1>
   <p class="sub-text">ワンちゃんのためのレシピ管理を始めましょう</p>
 
-  <div class="hero-image">
-    <img src="https://placehold.co/400x250" alt="dog food">
-  </div>
-
-  <div class="mt-4" style="max-width:400px;margin:auto;">
-
-    <%= form_with model:@user, local:true do |f| %>
-
-      <div class="mb-3 text-start">
-        <%= f.label :last_name,"姓" %>
-        <%= f.text_field :last_name,class:"form-control" %>
-      </div>
-
-      <div class="mb-3 text-start">
-        <%= f.label :first_name,"名" %>
-        <%= f.text_field :first_name,class:"form-control" %>
-      </div>
-
-      <div class="mb-3 text-start">
-        <%= f.label :nickname,"ニックネーム" %>
-        <%= f.text_field :nickname,class:"form-control" %>
-      </div>
-
-
-      <div class="mb-3 text-start">
-        <%= f.label :email,"メールアドレス" %>
-        <%= f.email_field :email,class:"form-control" %>
-      </div>
-
-      <div class="mb-3 text-start">
-        <%= f.label :password,"パスワード" %>
-        <%= f.password_field :password,class:"form-control" %>
-      </div>
-
-      <div class="mb-3 text-start">
-        <%= f.label :password_confirmation,"パスワード確認" %>
-        <%= f.password_field :password_confirmation,class:"form-control" %>
-      </div>
-
-      <%= f.submit "登録する",class:"primary-button" %>
-
-    <% end %>
-
-  </div>
-
+   
+   <%= render "form", submit_text: "登録する" %>
+   
   <p class="note mt-4">
     すでにアカウントをお持ちですか？
   </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,9 @@ Rails.application.routes.draw do
   end
 end
 
+  # ユーザー情報
+  resource :user, only: [:edit, :update]
+
     # パスワードリセット
     resources :password_resets, only: [ :new, :create, :edit, :update ]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,7 +71,7 @@ Rails.application.routes.draw do
 end
 
   # ユーザー情報
-  resource :user, only: [:edit, :update]
+  resource :user, only: [ :edit, :update ]
 
     # パスワードリセット
     resources :password_resets, only: [ :new, :create, :edit, :update ]


### PR DESCRIPTION
**概要**
dashboardにてユーザー情報の編集ができるように動線の追加

**編集内容**

- app/views/users/_form.html.erb
の作成、renderにて読み込みに。
- app/views/users/edit.html.erb
- routes追加　　resource :user, only: [:edit, :update]
- @user.new_record?にてログインユーザーにはパスワード登録はでないように。その代わりパスワード変更画面(new_password_reset_path)に飛ぶように編集