### PR TITLE
プライバシーポリシーの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 
-/app/assets/builds/*
+#/app/assets/builds/*
 !/app/assets/builds/.keep
 
 /node_modules

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,9 @@
+class StaticPagesController < ApplicationController
+  skip_before_action :require_login, only: [ :privacy_policy, :terms_of_service ]
+
+  def privacy_policy
+  end
+
+  def terms_of_service
+  end
+end

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -1,0 +1,2 @@
+module StaticPagesHelper
+end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -6,6 +6,11 @@
           <p>Copyright © 2026. One Wan Dish</p>
         </div>
       </div>
+      <div class="container mx-auto px-4 text-center">
+    <%= link_to 'プライバシーポリシー', privacy_policy_path, class: 'mx-2 hover:underline' %>
+    |
+    <%= link_to '利用規約', terms_of_service_path, class: 'mx-2 hover:underline' %>
+  </div>
     </div>
   </div>
 </footer>

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -1,0 +1,48 @@
+<<div class="container mt-5">
+  <div class="text-center mb-5"><h1>プライバシーポリシー</h1>
+  
+  <section class="mb-8">
+    <h2 class="text-center mb-5">1. 収集する情報</h2>
+    <p class="mb-4">
+      当サービスでは、以下の情報を収集します:
+    </p>
+    <ul div class="text-center mb-5">
+      <p>ユーザー登録時に提供いただく情報（メールアドレス、ユーザー名など）</p>
+      <p>サービス利用時に投稿されるコンテンツ</p>
+      <p>アクセスログ、Cookie情報</p>
+    </ul>
+  </section>
+  
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold mb-4">2. 利用目的</h2>
+    <p class="mb-4">
+      収集した情報は以下の目的で利用します。
+    </p>
+    <ul class="text-center mb-5">
+      <p>サービスの提供・運営</p>
+      <p>ユーザーサポート</p>
+      <p>サービスの改善・分析</p>
+    </ul>
+  </section>
+  
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold mb-4">3. 第三者提供</h2>
+    <p class="mb-4">
+      収集した個人情報は、法令に基づく場合を除き、第三者に提供することはありません。
+    </p>
+  </section>
+  
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold mb-4">4. お問い合わせ</h2>
+    <p class="mb-4">
+      プライバシーポリシーに関するお問い合わせは、以下までご連絡ください。<br>
+      メールアドレス: your-email@example.com
+    </p>
+  </section>
+  
+  <p class="text-sm text-gray-600 mt-8">
+    制定日: <%= Date.today.strftime('%Y年%m月%d日') %>
+  </p>
+</div>
+
+<div class="text-center mb-5"><%= link_to '戻る', :back %> 

--- a/app/views/static_pages/terms_of_service.html.erb
+++ b/app/views/static_pages/terms_of_service.html.erb
@@ -1,0 +1,248 @@
+<div class="container mx-auto px-4 py-8 max-w-4xl">
+  <h1 class="text-3xl font-bold mb-6">利用規約</h1>
+  
+  <section class="mb-8">
+  <h2 class="text-2xl font-semibold mb-4">第1条（適用）</h2>
+  <p class="mb-4">
+    本規約は、ワンワンディッシュ（以下「当サービス」といいます）の
+    利用に関する条件を定めるものです。
+    ユーザーの皆様には、本規約に従って当サービスをご利用いただきます。
+  </p>
+  <p class="mb-4">
+    当サービスを利用された場合、本規約に同意したものとみなします。
+  </p>
+</section>
+
+<section class="mb-8">
+  <h2 class="text-2xl font-semibold mb-4">第2条（利用登録）</h2>
+  <p class="mb-4">
+    当サービスの利用を希望する方は、本規約に同意の上、
+    所定の方法によって利用登録を申請してください。
+  </p>
+  <p class="mb-4">
+    以下のいずれかに該当する場合、利用登録を承認しないことがあります:
+  </p>
+  <ul class="list-disc ml-6 mb-4">
+    <li>虚偽の情報を登録した場合</li>
+    <li>過去に利用規約違反等により登録を抹消された方からの申請</li>
+    <li>その他、当サービスが不適切と判断した場合</li>
+  </ul>
+</section>
+
+<section class="mb-8">
+  <h2 class="text-2xl font-semibold mb-4">第3条（アカウント管理）</h2>
+  <p class="mb-4">
+    ユーザーは、自己の責任において、アカウント情報を管理するものとします。
+  </p>
+  <p class="mb-4">
+    アカウント情報の管理不十分、使用上の過誤、第三者の使用等による
+    損害の責任はユーザーが負うものとし、当サービスは一切の責任を負いません。
+  </p>
+  <p class="mb-4">
+    アカウント情報が盗まれたり、第三者に使用されていることが判明した場合、
+    直ちに当サービスにご連絡ください。
+  </p>
+</section>
+
+<section class="mb-8">
+  <h2 class="text-2xl font-semibold mb-4">第4条（禁止事項）</h2>
+  <p class="mb-4">
+    ユーザーは、当サービスの利用にあたり、以下の行為をしてはなりません:
+  </p>
+  <ul class="list-disc ml-6 mb-4">
+    <li>法令または公序良俗に違反する行為</li>
+    <li>犯罪行為に関連する行為</li>
+    <li>虚偽の情報を登録する行為</li>
+    <li>他のユーザーまたは第三者の知的財産権を侵害する行為</li>
+    <li>他のユーザーまたは第三者のプライバシーを侵害する行為</li>
+    <li>他のユーザーまたは第三者に不利益、損害を与える行為</li>
+    <li>当サービスのネットワークまたはシステムに過度な負荷をかける行為</li>
+    <li>当サービスの運営を妨害するおそれのある行為</li>
+    <li>不正アクセスをし、またはこれを試みる行為</li>
+    <li>他のユーザーに関する個人情報等を収集または蓄積する行為</li>
+    <li>不正な目的を持って当サービスを利用する行為</li>
+    <li>その他、当サービスが不適切と判断する行為</li>
+  </ul>
+</section>
+
+<section class="mb-8">
+  <h2 class="text-2xl font-semibold mb-4">第5条（サービスの提供・変更・停止）</h2>
+  <p class="mb-4">
+    当サービスは、ユーザーへの事前の通知なく、サービスの内容を
+    変更または追加することがあります。
+  </p>
+  <p class="mb-4">
+    以下のいずれかに該当する場合、ユーザーに事前に通知することなく、
+    サービスの全部または一部の提供を停止または中断することがあります:
+  </p>
+  <ul class="list-disc ml-6 mb-4">
+    <li>サービスに係るシステムの保守点検または更新を行う場合</li>
+    <li>地震、落雷、火災、停電等の不可抗力により、サービスの提供が困難となった場合</li>
+    <li>その他、当サービスがサービスの提供が困難と判断した場合</li>
+  </ul>
+</section>
+
+<section class="mb-8">
+  <h2 class="text-2xl font-semibold mb-4">第6条（免責事項）</h2>
+  <p class="mb-4">
+    当サービスは、以下の事項について一切の責任を負いません:
+  </p>
+  <ul class="list-disc ml-6 mb-4">
+    <li>当サービスに掲載されている情報の正確性、完全性、有用性</li>
+    <li>当サービスのレシピ情報を参考にした結果生じた損害</li>
+    <li>ユーザーの愛犬の健康状態に関する一切の責任</li>
+    <li>サービスの利用によってユーザーが被った損害</li>
+    <li>サービスの中断、停止、終了によって生じた損害</li>
+  </ul>
+  <p class="mb-4 text-red-600 font-semibold">
+    ※ 犬の健康に関しては必ず獣医師にご相談ください。
+    当サービスは犬の健康に関する専門的なアドバイスを提供するものではありません。
+  </p>
+</section>
+
+<section class="mb-8">
+  <h2 class="text-2xl font-semibold mb-4">第7条（知的財産権）</h2>
+  <p class="mb-4">
+    当サービスに関する知的財産権は、すべて当サービスまたは
+    当サービスにライセンスを許諾している者に帰属します。
+  </p>
+  <p class="mb-4">
+    ユーザーが投稿したコンテンツの著作権は、ユーザーに帰属します。
+    ただし、ユーザーは当サービスに対し、投稿コンテンツを
+    サービス内で使用する権利を許諾するものとします。
+  </p>
+</section>
+
+<section class="mb-8">
+  <h2 class="text-2xl font-semibold mb-4">第8条（利用制限・登録抹消）</h2>
+  <p class="mb-4">
+    当サービスは、ユーザーが以下のいずれかに該当する場合、
+    事前の通知なく、ユーザーに対してサービスの全部または一部の
+    利用を制限し、またはユーザーとしての登録を抹消することができます:
+  </p>
+  <ul class="list-disc ml-6 mb-4">
+    <li>本規約のいずれかの条項に違反した場合</li>
+    <li>登録事項に虚偽の事実があることが判明した場合</li>
+    <li>当サービスからの連絡に対し、一定期間返答がない場合</li>
+    <li>その他、当サービスがサービスの利用を適当でないと判断した場合</li>
+  </ul>
+  <p class="mb-4">
+    当サービスは、本条に基づき当サービスが行った行為により
+    ユーザーに生じた損害について、一切の責任を負いません。
+  </p>
+</section>
+
+<section class="mb-8">
+  <h2 class="text-2xl font-semibold mb-4">第9条（退会）</h2>
+  <p class="mb-4">
+    ユーザーは、当サービスの定める方法により、いつでも退会することができます。
+  </p>
+  <p class="mb-4">
+    現在は、退会をご希望の場合、以下のお問い合わせ窓口までご連絡ください。
+    一部の場合を除き、速やかにアカウントおよび関連するすべてのデータを削除いたします。
+  </p>
+  <p class="mb-4">
+    お問い合わせ先: <a href="mailto:contact@one-wan-dish.com" class="text-blue-600 underline">contact@one-wan-dish.com</a>
+  </p>
+  <p class="mb-4 text-sm text-gray-600">
+    ※ 今後、サービス内で退会機能を実装予定です。
+  </p>
+</section>
+
+<section class="mb-8">
+  <h2 class="text-2xl font-semibold mb-4">第10条（サービス内容の変更・終了）</h2>
+  <p class="mb-4">
+    当サービスは、ユーザーに通知することなく、サービスの内容を
+    変更し、または提供を終了することができます。
+  </p>
+  <p class="mb-4">
+    サービスの提供を終了する場合は、可能な限り事前にユーザーに通知するよう努めます。
+  </p>
+  <p class="mb-4">
+    当サービスは、これによってユーザーに生じた損害について一切の責任を負いません。
+  </p>
+</section>
+
+<section class="mb-8">
+  <h2 class="text-2xl font-semibold mb-4">第11条（保証の否認）</h2>
+  <p class="mb-4">
+    当サービスは、サービスが以下の事項を満たすことを保証しません:
+  </p>
+  <ul class="list-disc ml-6 mb-4">
+    <li>ユーザーの特定の目的に適合すること</li>
+    <li>期待する機能・正確性・有用性を有すること</li>
+    <li>継続的に利用できること</li>
+    <li>不具合が生じないこと</li>
+  </ul>
+</section>
+
+<section class="mb-8">
+  <h2 class="text-2xl font-semibold mb-4">第12条（利用規約の変更）</h2>
+  <p class="mb-4">
+    当サービスは、必要と判断した場合、ユーザーに通知することなく、
+    いつでも本規約を変更することができます。
+  </p>
+  <p class="mb-4">
+    変更後の利用規約は、当サービスウェブサイトに掲載したときから効力を生じるものとします。
+  </p>
+  <p class="mb-4">
+    利用規約の変更後、サービスの利用を開始した場合、
+    変更後の利用規約に同意したものとみなします。
+  </p>
+</section>
+
+<section class="mb-8">
+  <h2 class="text-2xl font-semibold mb-4">第13条（個人情報の取り扱い）</h2>
+  <p class="mb-4">
+    当サービスは、ユーザーの個人情報を適切に取り扱うものとし、
+    詳細は別途定める <%= link_to 'プライバシーポリシー', privacy_policy_path, class: 'text-blue-600 underline' %> をご確認ください。
+  </p>
+</section>
+
+<section class="mb-8">
+  <h2 class="text-2xl font-semibold mb-4">第14条（通知・連絡）</h2>
+  <p class="mb-4">
+    当サービスからユーザーへの通知または連絡は、
+    当サービスのウェブサイト内での掲示、
+    電子メールの送信、または登録された連絡先への連絡等、
+    当サービスが適当と判断する方法により行います。
+  </p>
+  <p class="mb-4">
+    当サービスからの通知または連絡が、当サービスのウェブサイト内に掲示された場合、
+    掲示の時点で効力を生じるものとします。
+  </p>
+</section>
+
+<section class="mb-8">
+  <h2 class="text-2xl font-semibold mb-4">第15条（準拠法・裁判管轄）</h2>
+  <p class="mb-4">
+    本規約の解釈にあたっては、日本法を準拠法とします。
+  </p>
+  <p class="mb-4">
+    当サービスに関して紛争が生じた場合には、
+    当サービスの本店所在地を管轄する裁判所を専属的合意管轄とします。
+  </p>
+</section>
+
+<section class="mb-8">
+  <p class="text-sm text-gray-600">
+    制定日: 2025年1月1日<br>
+    最終更新日: 2025年1月1日
+  </p>
+</section>
+
+<section class="mb-8">
+  <h2 class="text-2xl font-semibold mb-4">お問い合わせ</h2>
+  <p class="mb-4">
+    本規約に関するお問い合わせは、下記の窓口までお願いいたします。
+  </p>
+  <p class="mb-4">
+    サービス名: One-Wan-Dish<br>
+    Eメールアドレス: <a href="mailto:contact@one-wan-dish.com" class="text-blue-600 underline">chura721chura@gmail.com</a>
+  </p>
+</section>
+
+<div class="text-center mb-5"><%= link_to '戻る', :back %> 
+
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "static_pages/privacy_policy"
+  get "static_pages/terms_of_service"
   get "password_resets/new"
   get "password_resets/edit"
   # get "user_sessions/new"
@@ -37,6 +39,11 @@ Rails.application.routes.draw do
   root "homes#top"
   # 使い方
   get "how_to", to: "homes#how_to"
+
+  # プライバシーポリシー
+  get "privacy_policy", to: "static_pages#privacy_policy"
+  get "terms_of_service", to: "static_pages#terms_of_service"
+
 
   # 愛犬情報
   resources :dogs, except: [ :show ] do

--- a/spec/helpers/static_pages_helper_spec.rb
+++ b/spec/helpers/static_pages_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the StaticPagesHelper. For example:
+#
+# describe StaticPagesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe StaticPagesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe "StaticPages", type: :request do
+  describe "GET /privacy_policy" do
+    it "returns http success" do
+      get "/static_pages/privacy_policy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /terms_of_service" do
+    it "returns http success" do
+      get "/static_pages/terms_of_service"
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/views/static_pages/privacy_policy.html.erb_spec.rb
+++ b/spec/views/static_pages/privacy_policy.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "static_pages/privacy_policy.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/static_pages/terms_of_service.html.erb_spec.rb
+++ b/spec/views/static_pages/terms_of_service.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "static_pages/terms_of_service.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
**目的**
信頼性向上のため法的ページを追加

**作業内容**

- 利用規約ページ作成
- プライバシーポリシー作成
- 未ログインでも閲覧可能にする
- フッターにリンク設置

**確認内容**

どの状態でも閲覧できる