### PR TITLE
ユーザー退会機能の追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -44,7 +44,7 @@ class UsersController < ApplicationController
     end
   end
 
-   #削除確認画面
+  # 削除確認画面
   def confirm_destroy
     @user = current_user
   end
@@ -52,13 +52,13 @@ class UsersController < ApplicationController
   # 実際の削除処理
   def destroy
     @user = current_user
-    
+
     # ユーザーを削除（関連データも自動削除される）
     @user.destroy!
-    
+
     # セッションをクリア
     logout
-    
+
     redirect_to root_path, notice: "アカウントを削除しました。ご利用ありがとうございました。"
   rescue ActiveRecord::RecordNotDestroyed => e
     redirect_to edit_user_path(@user), alert: "アカウントの削除に失敗しました。もう一度お試しください。"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -44,6 +44,25 @@ class UsersController < ApplicationController
     end
   end
 
+   #削除確認画面
+  def confirm_destroy
+    @user = current_user
+  end
+
+  # 実際の削除処理
+  def destroy
+    @user = current_user
+    
+    # ユーザーを削除（関連データも自動削除される）
+    @user.destroy!
+    
+    # セッションをクリア
+    logout
+    
+    redirect_to root_path, notice: "アカウントを削除しました。ご利用ありがとうございました。"
+  rescue ActiveRecord::RecordNotDestroyed => e
+    redirect_to edit_user_path(@user), alert: "アカウントの削除に失敗しました。もう一度お試しください。"
+  end
 
   private
 

--- a/app/models/dog.rb
+++ b/app/models/dog.rb
@@ -40,6 +40,7 @@ class Dog < ApplicationRecord
   enum_i18n :activity_level
 
   has_one_attached :avatar
+  has_many :recipe_calculations, dependent: :destroy
 
   validates :name, presence: true
   validates :size, presence: true

--- a/app/models/dog.rb
+++ b/app/models/dog.rb
@@ -40,7 +40,6 @@ class Dog < ApplicationRecord
   enum_i18n :activity_level
 
   has_one_attached :avatar
-  has_many :recipe_calculations, dependent: :destroy
 
   validates :name, presence: true
   validates :size, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,11 +17,13 @@ class User < ApplicationRecord
   validates :nickname, presence: true, unless: :admin?
 
     has_many :dogs, dependent: :destroy
-    has_many :recipes, dependent: :destroy
+    has_many :recipes, dependent: :nullify  #作成レシピは残したい
     has_many :bookmarks, dependent: :destroy
     has_many :bookmark_recipes, through: :bookmarks, source: :recipe
     has_one :dog, dependent: :destroy
 
+    # 削除前の処理
+    before_destroy :transfer_recipes_to_anonymous_user
 
     # ネストした属性を許可
     accepts_nested_attributes_for :dogs
@@ -38,4 +40,17 @@ class User < ApplicationRecord
     def deleted?
       deleted_at.present?
     end
+    private
+  
+  def transfer_recipes_to_anonymous_user
+    # 匿名ユーザーを取得（存在しない場合は作成）
+    anonymous_user = User.find_or_create_by!(email: 'deleted_user@example.com') do |user|
+      user.name = '不明なユーザー'
+      user.password = SecureRandom.hex(32)
+      user.password_confirmation = user.password
+    end
+    
+    # レシピを匿名ユーザーに移管
+    recipes.update_all(user_id: anonymous_user.id)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
   validates :nickname, presence: true, unless: :admin?
 
     has_many :dogs, dependent: :destroy
-    has_many :recipes, dependent: :nullify  #作成レシピは残したい
+    has_many :recipes, dependent: :nullify  # 作成レシピは残したい
     has_many :bookmarks, dependent: :destroy
     has_many :bookmark_recipes, through: :bookmarks, source: :recipe
     has_one :dog, dependent: :destroy
@@ -41,15 +41,19 @@ class User < ApplicationRecord
       deleted_at.present?
     end
     private
-  
+
   def transfer_recipes_to_anonymous_user
-    # 匿名ユーザーを取得（存在しない場合は作成）
-    anonymous_user = User.find_or_create_by!(email: 'deleted_user@example.com') do |user|
-      user.name = '不明なユーザー'
+    # レシピがない場合は何もしない
+    return if recipes.empty?
+
+    # レシピ作成ユーザーのみ匿名ユーザーへ
+    anonymous_user = User.find_or_create_by!(email: "deleted_user@example.com") do |user|
+      user.name = "削除されたユーザー"
+      user.nickname = "不明なユーザー"
       user.password = SecureRandom.hex(32)
       user.password_confirmation = user.password
     end
-    
+
     # レシピを匿名ユーザーに移管
     recipes.update_all(user_id: anonymous_user.id)
   end

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -1,4 +1,4 @@
-<<div class="container mt-5">
+<div class="container mt-5">
   <div class="text-center mb-5"><h1>プライバシーポリシー</h1>
   
   <section class="mb-8">
@@ -45,4 +45,18 @@
   </p>
 </div>
 
-<div class="text-center mb-5"><%= link_to '戻る', :back %> 
+<div class="text-center mt-8 space-y-4">
+    <!-- メインの戻るボタン -->
+    <div>
+      <button onclick="window.history.back()" 
+              class="bg-gray-200 hover:bg-gray-300 text-gray-700 font-semibold py-2 px-6 rounded">
+        前のページに戻る
+      </button>
+    </div>
+    
+    <!-- 代替リンク（履歴がない場合や外部サイトから来た場合） -->
+    <div class="text-sm text-gray-600">
+      <span>または</span>
+      <%= link_to 'トップページ', root_path, class: 'text-blue-600 hover:underline mx-2' %>
+    </div>
+</div>

--- a/app/views/static_pages/terms_of_service.html.erb
+++ b/app/views/static_pages/terms_of_service.html.erb
@@ -242,7 +242,21 @@
   </p>
 </section>
 
-<div class="text-center mb-5"><%= link_to '戻る', :back %> 
+<div class="text-center mt-8 space-y-4">
+    <!-- メインの戻るボタン -->
+    <div>
+      <button onclick="window.history.back()" 
+              class="bg-gray-200 hover:bg-gray-300 text-gray-700 font-semibold py-2 px-6 rounded">
+        前のページに戻る
+      </button>
+    </div>
+    
+    <!-- 代替リンク（履歴がない場合や外部サイトから来た場合） -->
+    <div class="text-sm text-gray-600">
+      <span>または</span>
+      <%= link_to 'トップページ', root_path, class: 'text-blue-600 hover:underline mx-2' %>
+    </div>
+</div>
 
 
 

--- a/app/views/users/confirm_destroy.html.erb
+++ b/app/views/users/confirm_destroy.html.erb
@@ -1,0 +1,33 @@
+<div class="top-container">
+  <h1 class="accent">アカウント削除の確認</h1>
+  <p class="sub-text">本当にアカウントを削除しますか?</p>
+
+  <div class="mt-4" style="max-width:500px;margin:auto;">
+    <div class="alert alert-warning" role="alert">
+      <h4 class="alert-heading">⚠️ 削除すると以下のデータがすべて失われます</h4>
+      <ul class="mt-3">
+        <li>登録したユーザー情報</li>
+        <li>愛犬の情報（名前、年齢、体重など）</li>
+        <li>愛犬に合わせたレシピの計算結果</li>
+        <li>お気に入りのレシピ</li>
+      </ul>
+      <hr>
+      <p class="mb-0">
+        <strong>この操作は取り消せません。</strong><br>
+        削除したデータは復元できませんので、ご注意ください。
+      </p>
+    </div>
+
+    <div class="d-flex justify-content-center gap-3 mt-4">
+      <%= link_to "キャンセル", edit_user_path(current_user), class: "secondary-button" %>
+      <%= button_to "削除する", 
+                    user_path(current_user), 
+                    method: :delete,
+                    data: { 
+                      turbo_confirm: "本当に削除してもよろしいですか？この操作は取り消せません。",
+                      turbo_method: :delete 
+                    },
+                    class: "btn btn-danger" %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/confirm_destroy.html.erb
+++ b/app/views/users/confirm_destroy.html.erb
@@ -18,16 +18,16 @@
       </p>
     </div>
 
-    <div class="d-flex justify-content-center gap-3 mt-4">
-      <%= link_to "キャンセル", edit_user_path(current_user), class: "secondary-button" %>
-      <%= button_to "削除する", 
-                    user_path(current_user), 
-                    method: :delete,
-                    data: { 
-                      turbo_confirm: "本当に削除してもよろしいですか？この操作は取り消せません。",
-                      turbo_method: :delete 
-                    },
-                    class: "btn btn-danger" %>
-    </div>
+    <div class="d-flex flex-column align-items-center gap-3 mt-4">
+  <%= button_to "削除する", 
+        user_path(current_user), 
+        method: :delete,
+        data: { turbo_confirm: "本当に削除してもよろしいですか？この操作は取り消せません。" },
+        class: "btn btn-danger" %>
+
+  <%= link_to "キャンセル", 
+        edit_user_path(current_user), 
+        class: "secondary-button" %>
+</div>
   </div>
 </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -9,4 +9,12 @@
 
   <%= link_to "パスワードを変更", new_password_reset_path, class:"secondary-button"%>
   <%= link_to "戻る", root_path, class:"secondary-button" %>
+
+  <!-- 削除ボタン -->
+    <div class="mt-4 pt-4 border-top">
+      <%= link_to "アカウントを削除する", 
+                  confirm_destroy_user_path(current_user), 
+                  class: "btn btn-link text-danger text-decoration-none small" %>
+    </div>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   get "signup", to: "users#new"
   post "users", to: "users#create"
 
-   # ユーザー情報
+  # ユーザー情報
   resource :user, only: [ :edit, :update, :destroy  ] do
     member do
       get :confirm_destroy  # 削除確認画面

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,13 @@ Rails.application.routes.draw do
   get "signup", to: "users#new"
   post "users", to: "users#create"
 
+   # ユーザー情報
+  resource :user, only: [ :edit, :update, :destroy  ] do
+    member do
+      get :confirm_destroy  # 削除確認画面
+    end
+  end
+
   # ログイン後のダッシュボード
   get "dashboard", to: "homes#dashboard"
 
@@ -79,8 +86,6 @@ Rails.application.routes.draw do
   end
 end
 
-  # ユーザー情報
-  resource :user, only: [ :edit, :update ]
 
     # パスワードリセット
     resources :password_resets, only: [ :new, :create, :edit, :update ]


### PR DESCRIPTION
## 概要
ユーザー削除機能を実装しました。
ユーザー削除時にレシピを保持するため、匿名ユーザーにレシピを移管する仕組みを追加しました。

## 変更内容

### 1. ユーザー削除機能の実装
- 削除確認ページ（`confirm_destroy`）を追加
- ユーザー削除処理（`destroy`）を実装
- 削除後はトップページにリダイレクト

### 2. レシピ保持機能の追加
- ユーザー削除時にレシピを匿名ユーザーに移管
- レシピがある場合のみ匿名ユーザーを作成するよう最適化
- レシピ作成をしていないユーザーはそのまま削除

### 3. モデルの修正
- `User`モデルに`before_destroy`コールバックを追加
- レシピの削除方法を`dependent: :nullify`に変更

### 4. ルーティングの追加
- `GET /user/confirm_destroy` - 削除確認ページ
- `DELETE /user` - ユーザー削除処理


### レシピ保持の仕組み
```ruby
# ユーザー削除時の処理フロー
1. before_destroyコールバックが実行される
2. レシピの有無を確認
3. レシピがある場合のみ匿名ユーザーを作成
4. レシピを匿名ユーザーに移管
5. 犬のデータを削除（dependent: :destroy）
6. ユーザーを削除