### PR TITLE
レシピ投稿時のハッシュを正しく受け渡す

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem "jbuilder"
 # gem "redis", ">= 4.0.1"
 gem "meta-tags"
 
+gem 'enum_help'
+
 gem "letter_opener_web", "~> 2.0"
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem "jbuilder"
 # gem "redis", ">= 4.0.1"
 gem "meta-tags"
 
-gem 'enum_help'
+gem "enum_help"
 
 gem "letter_opener_web", "~> 2.0"
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -4,36 +4,82 @@ class RecipesController < ApplicationController
 
   def new
     @recipe = Recipe.new
+
+    # ★ セッションから入力内容を復元
+    if session[:recipe_draft].present?
+      draft = session[:recipe_draft]
+      @recipe.assign_attributes(draft.except("ingredients_json"))
+      @recipe.ingredients_json = draft["ingredients_json"]
+      session.delete(:recipe_draft)  # 復元後はセッションをクリア
+    end
   end
 
   def confirm
-    @recipe = current_user.recipes.build(recipe_params)
+  @recipe = current_user.recipes.build(recipe_params)
 
-    filtered = recipe_params[:ingredients_json]["medium"].reject do |i|
+  # ingredients_json を正規化
+  if recipe_params[:ingredients_json].present? && recipe_params[:ingredients_json]["medium"].present?
+    medium_ingredients = recipe_params[:ingredients_json]["medium"]
+
+    # 正規化処理
+    normalized = if medium_ingredients.is_a?(Hash)
+      # ハッシュ形式の場合は配列に変換
+      medium_ingredients.values.map do |ingredient|
+        {
+          "name" => ingredient["name"],
+          "amount" => ingredient["amount"],
+          "unit" => ingredient["unit"]
+        }
+      end
+    elsif medium_ingredients.is_a?(Array)
+      # すでに配列形式ならそのまま
+      medium_ingredients.map do |ingredient|
+        {
+          "name" => ingredient["name"],
+          "amount" => ingredient["amount"],
+          "unit" => ingredient["unit"]
+        }
+      end
+    else
+      # それ以外の場合は空配列
+      []
+    end
+
+    # 空の材料を除外
+    filtered = normalized.reject do |i|
       i["name"].blank? || i["amount"].blank?
     end
 
-    @recipe.ingredients_json["medium"] = filtered
-    @recipe.status = "draft"
-
-    # バリデーションチェック
-    unless @recipe.valid?
-      flash.now[:alert] = "入力内容を確認してください"
-      render :new, status: :unprocessable_entity
-    end
+    # ★ ここで @recipe.ingredients_json に代入
+    @recipe.ingredients_json = { "medium" => filtered }
   end
+
+  @recipe.status = "draft"
+
+  # バリデーションチェック
+  unless @recipe.valid?
+    flash.now[:alert] = "入力内容を確認してください"
+    render :new, status: :unprocessable_entity
+  end
+end
 
   def create
-    @recipe = current_user.recipes.build(recipe_params)
-    @recipe.status = "draft"
+  @recipe = current_user.recipes.build(recipe_params)
+  @recipe.status = "draft"
 
-    if @recipe.save
-      redirect_to recipes_path, notice: "レシピを保存しました。管理者の承認後に公開されます。"
-    else
-      flash.now[:alert] = "レシピの保存に失敗しました。入力内容を確認してください。"
-      render :new, status: :unprocessable_entity
-    end
+  # ★ JSON文字列をパースして ingredients_json に代入
+  if params[:recipe][:ingredients_json_string].present?
+    @recipe.ingredients_json = JSON.parse(params[:recipe][:ingredients_json_string])
   end
+
+  if @recipe.save
+    redirect_to recipes_path, notice: "レシピを保存しました。管理者の承認後に公開されます。"
+  else
+    flash.now[:alert] = "レシピの保存に失敗しました。入力内容を確認してください。"
+    render :new, status: :unprocessable_entity
+  end
+end
+
 
 
   def index

--- a/app/views/recipes/confirm.html.erb
+++ b/app/views/recipes/confirm.html.erb
@@ -6,39 +6,34 @@
   <%= hidden_field_tag "recipe[description]", @recipe.description %>
   <%= hidden_field_tag "recipe[instructions]", @recipe.instructions %>
   <%= hidden_field_tag "recipe[nutrition_note]", @recipe.nutrition_note %>
-
-  <% @recipe.ingredients_json["medium"].each_with_index do |ingredient, i| %>
-    <% next if ingredient["name"].blank? || ingredient["amount"].blank? %>
-
-    <%= hidden_field_tag "recipe[ingredients_json][medium][#{i}][name]", ingredient["name"] %>
-    <%= hidden_field_tag "recipe[ingredients_json][medium][#{i}][amount]", ingredient["amount"] %>
-    <%= hidden_field_tag "recipe[ingredients_json][medium][#{i}][unit]", ingredient["unit"] %>
-  <% end %>
-
   <%= hidden_field_tag "recipe[age_stage]", @recipe.age_stage %>
   <%= hidden_field_tag "recipe[body_type]", @recipe.body_type %>
   <%= hidden_field_tag "recipe[activity_level]", @recipe.activity_level %>
 
- <div class="text-center mt-5">
-  <%= link_to "修正する",
-  new_recipe_path(recipe: params[:recipe].permit!),
-  class: "btn me-3",
-  style: "
-    border-radius: 30px;
-    padding: 10px 25px;
-    border: 2px solid #ccc;
-    color: #555;
-  " %>
+  <%# JSON文字列として送信 %>
+  <%= hidden_field_tag "recipe[ingredients_json_string]", @recipe.ingredients_json.to_json %>
 
-  <%= f.submit "レシピを投稿する",
-    class: "btn",
-    style: "
-      background-color: #f4a300;
-      color: white;
-      border-radius: 30px;
-      padding: 10px 25px;
-      font-weight: bold;
-    " %>
-</div>
+  <div class="text-center mt-5">
+    <%# ★ 修正する: セッションに保存してから new_recipe_path へ %>
+    <%= link_to "修正する",
+      new_recipe_path,
+      class: "btn me-3",
+      style: "
+        border-radius: 30px;
+        padding: 10px 25px;
+        border: 2px solid #ccc;
+        color: #555;
+      " %>
+
+    <%= f.submit "レシピを投稿する",
+      class: "btn",
+      style: "
+        background-color: #f4a300;
+        color: white;
+        border-radius: 30px;
+        padding: 10px 25px;
+        font-weight: bold;
+      " %>
+  </div>
 
 <% end %>

--- a/app/views/recipes/new.html.erb
+++ b/app/views/recipes/new.html.erb
@@ -80,30 +80,30 @@
 </div>
 
   <div class="row">
-    <!-- 年齢 -->
-    <div class="col-md-4">
-      <%= f.label :age_stage, "このレシピの該当タイプ" %>
-      <%= f.select :age_stage,
-  Dog.age_stages.keys.map { |k| [t("enums.dog.age_stage.#{k}"), k] },
-  {}, class: "form-select" %>
-    </div>
-
-    <!-- 体型 -->
-    <div class="col-md-4">
-      <%= f.label :body_type, "体型" %>
-      <%= f.select :body_type,
-  Dog.body_types.keys.map { |k| [t("enums.dog.body_type.#{k}"), k] },
-  {}, class: "form-select" %>
-    </div>
-
-    <!-- 運動量 -->
-    <div class="col-md-4">
-      <%= f.label :activity_level, "運動量" %>
-      <%= f.select :activity_level,
-  Dog.activity_levels.keys.map { |k| [t("enums.dog.activity_level.#{k}"), k] },
-  {}, class: "form-select" %>
-    </div>
+  <!-- 年齢 -->
+  <div class="col-md-4">
+    <%= f.label :age_stage, "このレシピの該当タイプ" %>
+    <%= f.select :age_stage,
+        Recipe.age_stages.keys.map { |k| [t("enums.dog.age_stage.#{k}"), k] },
+        {}, class: "form-select" %>
   </div>
+
+  <!-- 体型 -->
+  <div class="col-md-4">
+    <%= f.label :body_type, "体型" %>
+    <%= f.select :body_type,
+        Recipe.body_types.keys.map { |k| [t("enums.dog.body_type.#{k}"), k] },
+        {}, class: "form-select" %>
+  </div>
+
+  <!-- 運動量 -->
+  <div class="col-md-4">
+    <%= f.label :activity_level, "運動量" %>
+    <%= f.select :activity_level,
+        Recipe.activity_levels.keys.map { |k| [t("enums.dog.activity_level.#{k}"), k] },
+        {}, class: "form-select" %>
+  </div>
+</div>
 
       <!-- 作り方 -->
       <div class="mb-3">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -61,5 +61,52 @@ ja:
           鮭: 鮭
           マグロ: マグロ
           タラ: タラ
+
+  enums:  
+    dog:
+      age_stage:
+        puppy: "子犬"
+        adult: "成犬"
+        senior: "シニア"
+      size:
+        small: "小型犬"
+        medium: "中型犬"
+        large: "大型犬"
+      body_type:
+        thin: "痩せ型"
+        normal: "標準"
+        overweight: "肥満"
+      activity_level:
+        low: "穏やか"
+        medium: "普通"
+        high: "活発"
+      allergy:
+        牛肉: 牛肉
+        鶏肉: 鶏肉
+        豚肉: 豚肉
+        牛乳: 牛乳
+        チーズ: チーズ
+        ヨーグルト: ヨーグルト
+        卵: 卵
+        鹿肉: 鹿肉
+        納豆(大豆): 納豆(大豆)
+        鮭: 鮭
+        マグロ: マグロ
+        タラ: タラ
+
+    recipe:
+      age_stage:
+        puppy: "子犬"
+        adult: "成犬"
+        senior: "シニア"
+      body_type:
+        thin: "痩せ型"
+        normal: "標準"
+        overweight: "肥満"
+      activity_level:
+        low: "穏やか"
+        medium: "普通"
+        high: "活発"
+          
     
  


### PR DESCRIPTION
### 概要
最低限のセキュリティ担保の確認時に発見された、レシピ投稿者以外が投稿された該当レシピに飛ぶとエラーになるのを解消

**作業内容**
- ハッシュ形式 {"0"=>{"name"=>"米"}} を配列形式 [{"name"=>"米"}] に変更できていなかった。
- i18nがenumをactiverecordにいれたことで動かない事案を修正
- パスワード暗号化確認（bcrypt）
- 認証フィルタ確認
- 管理画面制限
- パラメータチェック

**変更内容**

-  i18nがenumをactiverecord内と外それぞれに用意する
- privetaからviewで呼び出していたため修正