### PR TITLE
遷移先の修正

### DIFF
--- a/app/controllers/admin/recipes_controller.rb
+++ b/app/controllers/admin/recipes_controller.rb
@@ -45,7 +45,7 @@ class Admin::RecipesController < Admin::BaseController  # ← ここを変更
     end
   end
 
-  
+
   private
 
   def set_recipe

--- a/app/controllers/admin/recipes_controller.rb
+++ b/app/controllers/admin/recipes_controller.rb
@@ -35,6 +35,11 @@ class Admin::RecipesController < Admin::BaseController  # ← ここを変更
     end
   end
 
+  # 却下レシピ一覧
+  def rejected
+    @recipes = Recipe.rejected.order(updated_at: :desc)
+  end
+
   private
 
   def set_recipe

--- a/app/controllers/admin/recipes_controller.rb
+++ b/app/controllers/admin/recipes_controller.rb
@@ -11,35 +11,41 @@ class Admin::RecipesController < Admin::BaseController  # ← ここを変更
     @recipes = Recipe.published.order(updated_at: :desc)
   end
 
+  # 却下レシピ一覧
+  def rejected
+    @recipes = Recipe.rejected.order(updated_at: :desc)
+  end
+
+
   def show
   end
 
   def update
-  # 下書き状態のレシピのみ更新可能にする
-  unless @recipe.draft?
-    redirect_to admin_recipes_path, alert: "このレシピは既に処理されています"
-    return
-  end
-
     case params[:commit]
     when I18n.t("admin.recipes.actions.approve")
-      @recipe.published!
-      redirect_to published_admin_recipes_path, notice: "承認済みに移動しました"
+      # 下書き または 却下済み の場合のみ承認可能
+      if @recipe.draft? || @recipe.rejected?
+        @recipe.published!
+        redirect_to published_admin_recipes_path, notice: "承認しました"
+      else
+        redirect_to admin_recipes_path, alert: "このレシピは既に承認されています"
+      end
 
     when I18n.t("admin.recipes.actions.reject")
-      @recipe.rejected!
-      redirect_to admin_recipes_path, notice: "却下しました"
+      # 下書き または 承認済み の場合のみ却下可能
+      if @recipe.draft? || @recipe.published?
+        @recipe.rejected!
+        redirect_to rejected_admin_recipes_path, notice: "却下しました"
+      else
+        redirect_to admin_recipes_path, alert: "このレシピは既に却下されています"
+      end
 
     else
       redirect_to admin_recipes_path, alert: "不正な操作です"
     end
   end
 
-  # 却下レシピ一覧
-  def rejected
-    @recipes = Recipe.rejected.order(updated_at: :desc)
-  end
-
+  
   private
 
   def set_recipe

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,7 +31,7 @@ class ApplicationController < ActionController::Base
     return unless current_user.dogs.empty?
     return if controller_name.in?(%w[dogs user_sessions])
 
-    redirect_to new_dog_path, alert: "犬のプロフィールを登録してください"
+    redirect_to new_dog_path, notice: "登録ありがとうございます!次に愛犬の情報を登録してください。"
   end
 
   # ユーザーチェックをスキップする条件

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -73,7 +73,7 @@ end
   end
 
   if @recipe.save
-    redirect_to recipes_path, notice: "レシピを保存しました。管理者の承認後に公開されます。"
+    redirect_to select_action_recipes_path, notice: "レシピを保存しました。管理者の承認後に公開されます。"
   else
     flash.now[:alert] = "レシピの保存に失敗しました。入力内容を確認してください。"
     render :new, status: :unprocessable_entity

--- a/app/views/admin/recipes/rejected.html.erb
+++ b/app/views/admin/recipes/rejected.html.erb
@@ -1,0 +1,43 @@
+<div class="container mt-5" style="max-width: 800px;">
+  <div class="card shadow-lg p-5 rounded-4 border-0">
+    
+    <h2 class="fw-bold mb-4 text-center" style="color:#d9534f;">
+      ❌ 却下したレシピ一覧
+    </h2>
+
+    <% if @recipes.present? %>
+      <div class="list-group">
+        <% @recipes.each do |recipe| %>
+          <div class="list-group-item mb-3 p-4 rounded-3 shadow-sm border">
+            <div class="d-flex justify-content-between align-items-center">
+              <div>
+                <h5 class="mb-2 fw-bold"><%= recipe.name %></h5>
+                <p class="text-muted mb-2"><%= truncate(recipe.description, length: 80) %></p>
+                <small class="text-muted">
+                  却下日: <%= l recipe.updated_at, format: :long %>
+                </small>
+              </div>
+              <div>
+                <%= link_to "詳細", 
+                      admin_recipe_path(recipe), 
+                      class: "btn btn-outline-danger btn-sm" %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="text-center py-5">
+        <i class="bi bi-inbox" style="font-size: 3rem; color: #ccc;"></i>
+        <p class="text-muted mt-3">却下したレシピはまだありません</p>
+      </div>
+    <% end %>
+
+    <div class="text-center mt-4">
+      <%= link_to "ダッシュボードに戻る", 
+            dashboard_path, 
+            class: "btn btn-secondary px-4 rounded-pill" %>
+    </div>
+
+  </div>
+</div>

--- a/app/views/admin/recipes/show.html.erb
+++ b/app/views/admin/recipes/show.html.erb
@@ -9,23 +9,39 @@
 
     <div class="d-flex justify-content-center gap-3 mt-4">
       <%= form_with model: [:admin, @recipe], method: :patch do |f| %>
-        <%# 下書き状態の場合のみ承認ボタンを表示 %>
-        <% if @recipe.draft? %>
+        <!-- 下書き または 却下済み の場合に承認ボタンを表示 -->
+        <% if @recipe.draft? || @recipe.rejected? %>
           <%= f.submit t("admin.recipes.actions.approve"),
                 name: "commit",
                 class: "btn btn-success px-4 rounded-pill" %>
         <% end %>
 
+        <!-- 下書き または 公開済み の場合に却下ボタンを表示 -->
+        <% if @recipe.draft? || @recipe.published? %>
           <%= f.submit t("admin.recipes.actions.reject"),
               name: "commit",
               class: "btn btn-danger px-4 rounded-pill" %>
         <% end %>
+      <% end %>
     </div>
 
     <div class="text-center mt-4">
-      <%= link_to "一覧に戻る", admin_recipes_path,
-        class: "btn btn-secondary px-4 rounded-pill" %>
-    </div>
-
+  <% if @recipe.rejected? %>
+    <%# 却下済みレシピの場合 %>
+    <%= link_to "却下済み一覧に戻る", 
+          admin_rejected_recipes_path,
+          class: "btn btn-secondary px-4 rounded-pill" %>
+  <% elsif @recipe.published? %>
+    <%# 承認済みレシピの場合（将来的に承認済み一覧を作る場合） %>
+    <%= link_to "承認済み一覧に戻る", 
+          published_admin_recipes_path,
+          class: "btn btn-secondary px-4 rounded-pill" %>
+  <% else %>
+    <%# 未承認レシピの場合 %>
+    <%= link_to "一覧に戻る", 
+          admin_recipes_path,
+          class: "btn btn-secondary px-4 rounded-pill" %>
+  <% end %>
+</div>
   </div>
 </div>

--- a/app/views/admin/recipes/show.html.erb
+++ b/app/views/admin/recipes/show.html.erb
@@ -9,14 +9,17 @@
 
     <div class="d-flex justify-content-center gap-3 mt-4">
       <%= form_with model: [:admin, @recipe], method: :patch do |f| %>
-        <%= f.submit t("admin.recipes.actions.approve"),
-  name: "commit",
-  class: "btn btn-success px-4 rounded-pill" %>
+        <%# 下書き状態の場合のみ承認ボタンを表示 %>
+        <% if @recipe.draft? %>
+          <%= f.submit t("admin.recipes.actions.approve"),
+                name: "commit",
+                class: "btn btn-success px-4 rounded-pill" %>
+        <% end %>
 
-<%= f.submit t("admin.recipes.actions.reject"),
-  name: "commit",
-  class: "btn btn-danger px-4 rounded-pill" %>
-      <% end %>
+          <%= f.submit t("admin.recipes.actions.reject"),
+              name: "commit",
+              class: "btn btn-danger px-4 rounded-pill" %>
+        <% end %>
     </div>
 
     <div class="text-center mt-4">

--- a/app/views/admin/recipes/show.html.erb
+++ b/app/views/admin/recipes/show.html.erb
@@ -29,10 +29,10 @@
   <% if @recipe.rejected? %>
     <%# 却下済みレシピの場合 %>
     <%= link_to "却下済み一覧に戻る", 
-          admin_rejected_recipes_path,
+          rejected_admin_recipes_path,
           class: "btn btn-secondary px-4 rounded-pill" %>
   <% elsif @recipe.published? %>
-    <%# 承認済みレシピの場合（将来的に承認済み一覧を作る場合） %>
+    <%# 承認済みレシピの場合 %>
     <%= link_to "承認済み一覧に戻る", 
           published_admin_recipes_path,
           class: "btn btn-secondary px-4 rounded-pill" %>

--- a/app/views/dogs/_form.html.erb
+++ b/app/views/dogs/_form.html.erb
@@ -160,9 +160,12 @@
               </div>
             <% end %>
 
-    <div class="back-button-container">
-      <%= link_to " 戻る ", root_path,
-          class: "back-button" %>
-    </div>
+    <!-- ★ 戻るボタン（条件付き表示） -->
+    <% if current_user.dogs.exists? %>
+      <div class="back-button-container">
+        <%= link_to " 戻る ", dashboard_path,
+            class: "back-button" %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/homes/dashboard.html.erb
+++ b/app/views/homes/dashboard.html.erb
@@ -237,7 +237,17 @@
 
       <%= link_to "確認する", published_admin_recipes_path, class: "btn btn-warning btn-lg" %>
   <% end %>
-<% end %>
+
+  <!-- 却下したレシピ -->
+  <%= render "homes/card",
+      icon: "bi-x-circle",
+      title: "却下したレシピ",
+      text: "却下したレシピの一覧を見る" do %>
+
+      <%= link_to "確認する", rejected_admin_recipes_path, class: "btn btn-warning btn-lg" %>
+  <% end %>
+  <% end %>
 
   </div>
-</div>
+ </div>
+ 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,7 @@ Rails.application.routes.draw do
     resources :recipes, only: [ :index, :show, :update ] do
       collection do
         get :published  # 承認済みレシピ一覧
+        get :rejected   # 却下レシピ一覧
       end
       get "dashboard", to: "dashboard#index"
   end


### PR DESCRIPTION
**概要**
最終調整の推移先などの変更、訂正を行なっています。

**変更箇所**
-admin-

- 管理者画面の承認ボタンを承認済みレシピには出さない
- 承認済みレシピ一覧からレシピ確認時、不備があった時用に却下ボタンのみ継続
- 却下したレシピ一覧の追加
- 却下したレシピを再度承認できるように承認ボタンのみ継続
- それぞれの画面の「戻る」ボタンの遷移先は元いた箇所の一覧に戻る

-一般画面-

- レシピ投稿後の遷移先をレシピ投稿のセレクト画面に修正
- 新規登録時、犬の情報登録のところは「戻る」ボタンを出さない
- 新規登録時の犬の情報登録の時にアラートがでてしまっていたのを修正