### PR TITLE
ログイン中は使い方画面でログインボタンでないように変更

### DIFF
--- a/app/views/homes/how_to.html.erb
+++ b/app/views/homes/how_to.html.erb
@@ -74,6 +74,7 @@
     </div>
   </div>
 
+  <% if current_user.nil? %>
   <!-- CTA セクション -->
   <div class="how-to-cta fade-in-section">
     <h3>さあ、はじめましょう!</h3>
@@ -83,6 +84,8 @@
       <%= link_to "ログイン", login_path, class: "secondary-button" %>
     </div>
 </div>
+<% end %>
+
 <!-- 戻るボタン -->
   <div class="back-button-container">
     <%= link_to "戻る", "javascript:history.back()", class: "back-button" %>


### PR DESCRIPTION
**概要**
使い方画面で「ログイン・新規登録」のボタンがログイン中でも出てしまっていたところを、未ログインユーザーにのみ出るように修正しています。

**変更箇所**
CATセクションに<% if current_user.nil? %>をつけることで選別。
ログインユーザーにはCATセクションがでないように修正